### PR TITLE
add `ObjectHeaderReader`, support `std::list`

### DIFF
--- a/cpp/include/uproot-custom/uproot-custom.hh
+++ b/cpp/include/uproot-custom/uproot-custom.hh
@@ -38,7 +38,7 @@ namespace uproot {
     const int32_t kMapOffset = 2; // first 2 map entries are taken by null obj and self obj
 
     class BinaryBuffer {
-
+      public:
         enum EStatusBits {
             kCanDelete = 1ULL << 0, ///< if object in a list can be deleted
             // 2 is taken by TDataMember
@@ -54,7 +54,6 @@ namespace uproot {
                              << 13 ///< if object ctor succeeded but object should not be used
         };
 
-      public:
         BinaryBuffer( py::array_t<uint8_t> data, py::array_t<uint32_t> offsets )
             : m_data( static_cast<uint8_t*>( data.request().ptr ) )
             , m_offsets( static_cast<uint32_t*>( offsets.request().ptr ) )

--- a/uproot_custom/__init__.py
+++ b/uproot_custom/__init__.py
@@ -5,11 +5,12 @@ import uproot.interpretation.identify
 from uproot_custom.AsBinary import AsBinary
 from uproot_custom.AsCustom import AsCustom, regularize_object_path
 from uproot_custom.readers import (
+    BaseObjectReader,
     BaseReader,
     BasicTypeReader,
     CArrayReader,
     EmptyReader,
-    ObjectReader,
+    ObjectHeaderReader,
     STLMapReader,
     STLSeqReader,
     STLStringReader,

--- a/uproot_custom/cpp.pyi
+++ b/uproot_custom/cpp.pyi
@@ -83,7 +83,14 @@ class TStringReader(IElementReader):
 class TObjectReader(IElementReader):
     def __init__(self, name: str) -> None: ...
 
-class ObjectReader(IElementReader):
+class BaseObjectReader(IElementReader):
+    def __init__(
+        self,
+        name: str,
+        element_readers: list[IElementReader],
+    ) -> None: ...
+
+class ObjectHeaderReader(IElementReader):
     def __init__(
         self,
         name: str,


### PR DESCRIPTION
This pull request introduces significant changes to the `uproot-custom` module, focusing on enhancing object reading capabilities, restructuring class hierarchies, and improving tree configuration handling. The most notable updates include the addition of new reader classes (`ObjectHeaderReader` and `BaseObjectReader`), modifications to tree configuration logic, and improvements to array reconstruction functionality.

### Enhancements to object reading:

- **Added `ObjectHeaderReader` class**: Introduced a new reader class to handle objects with headers, including methods for reading and reconstructing data. This class processes object headers and sub-readers to extract structured data. (`[[1]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aR338-R368)`, `[[2]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL792-R859)`, `[[3]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL844-R908)`)
- **Modified `TObjectReader` class**: Enhanced the `read` method to handle additional fields (`fVersion`, `fBits`, `pidf`) and updated the `data` method to return a tuple containing arrays for these fields. (`[[1]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL68-R101)`, `[[2]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aR623-R639)`)

### Refactoring and class hierarchy updates:

- **Renamed `ObjectReader` to `BaseObjectReader`**: Refactored the class to better reflect its role as a base reader for objects, and updated all references accordingly. (`[[1]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL270-R299)`, `[[2]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL402-R462)`, `[[3]](diffhunk://#diff-cf3cd0d3373cda0d93990dc75f1580b48b5f8ccaf9203fb68115754dbefb8ac9R8-R13)`, `[[4]](diffhunk://#diff-604d2ee8c589b1fe012047490d890e9434a089920a0933cf50fe702e41b76eb8L86-R93)`, `[[5]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL741-R756)`)
- **Updated registration of readers**: Registered new reader classes (`BaseObjectReader` and `ObjectHeaderReader`) and removed references to the old `ObjectReader` class. (`[[1]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL402-R462)`, `[[2]](diffhunk://#diff-cf3cd0d3373cda0d93990dc75f1580b48b5f8ccaf9203fb68115754dbefb8ac9R8-R13)`)

### Improvements to tree configuration handling:

- **Replaced `is_top` with `with_header`**: Updated tree configuration logic to use the `with_header` attribute for determining whether an object includes a header, simplifying the configuration process. (`[[1]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL309-R309)`, `[[2]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL323-R326)`, `[[3]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL391-R395)`, `[[4]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL411-R414)`, `[[5]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL467-R467)`, `[[6]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL691-R706)`)
- **Enhanced STL sequence handling**: Expanded support for STL containers by adding `list` to the recognized types in tree configuration generation. (`[[1]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL280-R280)`, `[[2]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL290-R290)`)

### Array reconstruction improvements:

- **Added support for structured arrays**: Enhanced array reconstruction methods to handle nested and structured data, including support for `fUniqueID`, `fBits`, and `pidf` fields. (`[[1]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aR623-R639)`, `[[2]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL792-R859)`, `[[3]](diffhunk://#diff-eb63d9b3963f4a275059f6168350da8d3fe7018099b74c780830396dab700e2aL844-R908)`)