### PR TITLE
support memberwise-reading for stl sequence-like objects

### DIFF
--- a/example/cpp/my_reader.cc
+++ b/example/cpp/my_reader.cc
@@ -67,7 +67,7 @@ class TObjArrayReader : public IElementReader {
         buffer.skip( 4 ); // fLowerBound
 
         m_offsets->push_back( m_offsets->back() + fSize );
-        m_element_reader->read( buffer, fSize );
+        m_element_reader->read_many( buffer, fSize );
     }
 
     py::object data() const override final {

--- a/example/gen-demo-data/src/main.cc
+++ b/example/gen-demo-data/src/main.cc
@@ -14,6 +14,7 @@
 #include "TSTLSeqWithObj.hh"
 #include "TSTLSequence.hh"
 #include "TSTLString.hh"
+#include "TSimpleObject.hh"
 
 int main() {
     TFile f( "demo-data.root", "RECREATE" );
@@ -49,6 +50,9 @@ int main() {
     TNestedSTL nested_stl;
     t.Branch( "nested_stl", &nested_stl );
 
+    TSimpleObject simple_obj;
+    t.Branch( "simple_obj", &simple_obj );
+
     TOverrideStreamer override_streamer;
     t.Branch( "override_streamer", &override_streamer );
 
@@ -70,6 +74,7 @@ int main() {
         stl_seq_with_obj = TSTLSeqWithObj();
         stl_map_with_obj = TSTLMapWithObj();
         nested_stl       = TNestedSTL();
+        simple_obj       = TSimpleObject();
 
         override_streamer  = TOverrideStreamer( i );
         complicated_stl    = TComplicatedSTL();

--- a/tests/test_AsGroupedMap.py
+++ b/tests/test_AsGroupedMap.py
@@ -7,7 +7,7 @@ as_grouped_map_branches = [
     "/my_tree:nested_stl/m_map3_str/m_map3_str.first",
     "/my_tree:nested_stl/m_map3_str/m_map3_str.second",
     "/my_tree:nested_stl/m_map_vec_obj/m_map_vec_obj.first",
-    "/my_tree:nested_stl/m_map_vec_obj/m_map_vec_obj.second",  # NOT WORKING
+    "/my_tree:nested_stl/m_map_vec_obj/m_map_vec_obj.second",
     "/my_tree:nested_stl/m_map_vec_str/m_map_vec_str.first",
     "/my_tree:nested_stl/m_map_vec_str/m_map_vec_str.second",
     "/my_tree:complicated_stl/m_map_vec_int/m_map_vec_int.first",
@@ -22,35 +22,14 @@ as_grouped_map_branches = [
     "/my_tree:complicated_stl/m_map_vec_list_set_int/m_map_vec_list_set_int.second",
 ]
 
-
 uproot_custom.AsGroupedMap.target_branches |= set(as_grouped_map_branches)
 
 
-@pytest.mark.parametrize(
-    "sub_branch_path",
-    [
-        (
-            pytest.param(i, marks=pytest.mark.xfail)
-            if i == "/my_tree:nested_stl/m_map_vec_obj/m_map_vec_obj.second"
-            else i
-        )
-        for i in as_grouped_map_branches
-    ],
-)
+@pytest.mark.parametrize("sub_branch_path", as_grouped_map_branches)
 def test_AsGroupedMap_array(f_test_data, sub_branch_path):
     f_test_data[sub_branch_path].array()
 
 
-@pytest.mark.parametrize(
-    "sub_branch_path",
-    [
-        (
-            pytest.param(i, marks=pytest.mark.xfail)
-            if i == "/my_tree:nested_stl/m_map_vec_obj/m_map_vec_obj.second"
-            else i
-        )
-        for i in as_grouped_map_branches
-    ],
-)
+@pytest.mark.parametrize("sub_branch_path", as_grouped_map_branches)
 def test_AsGroupedMap_dask(test_data_path, sub_branch_path):
     uproot.dask({test_data_path: sub_branch_path}).compute()

--- a/uproot_custom/__init__.py
+++ b/uproot_custom/__init__.py
@@ -6,13 +6,13 @@ from uproot_custom.AsBinary import AsBinary
 from uproot_custom.AsCustom import AsCustom
 from uproot_custom.AsGroupedMap import AsGroupedMap
 from uproot_custom.factories import (
+    AnyClassFactory,
     BaseFactory,
     BaseObjectFactory,
     BasicTypeFactory,
     CStyleArrayFactory,
     EmptyFactory,
     GroupFactory,
-    NBytesVersionFactory,
     ObjectHeaderFactory,
     STLMapFactory,
     STLSeqFactory,

--- a/uproot_custom/cpp.pyi
+++ b/uproot_custom/cpp.pyi
@@ -45,6 +45,7 @@ class STLSeqReader(IElementReader):
         self,
         name: str,
         with_header: bool,
+        objwise_or_memberwise: int,
         element_reader: IElementReader,
     ) -> None: ...
 
@@ -53,6 +54,7 @@ class STLMapReader(IElementReader):
         self,
         name: str,
         with_header: bool,
+        objwise_or_memberwise: int,
         key_reader: IElementReader,
         value_reader: IElementReader,
     ) -> None: ...
@@ -88,14 +90,14 @@ class TStringReader(IElementReader):
 class TObjectReader(IElementReader):
     def __init__(self, name: str) -> None: ...
 
-class NBytesVersionReader(IElementReader):
+class GroupReader(IElementReader):
     def __init__(
         self,
         name: str,
-        element_reader: IElementReader,
+        sub_readers: list[IElementReader],
     ) -> None: ...
 
-class GroupReader(IElementReader):
+class AnyClassReader(IElementReader):
     def __init__(
         self,
         name: str,


### PR DESCRIPTION
This pull request introduces significant improvements to the `uproot-custom` C++ library, focusing on enhanced support for member-wise streaming, improved error handling, and refactoring for clarity and extensibility. The changes primarily affect the reading logic for STL containers and composite data structures, introducing new flags and methods to distinguish between object-wise and member-wise reading modes. Additionally, several reader classes have been refactored or renamed for better organization and future extension.

**Support for member-wise streaming and refactoring of readers:**

* Added the `kStreamedMemberWise` mask constant to distinguish member-wise streaming in version flags, and refactored STL container readers (`STLSeqReader`, `STLMapReader`) to support both object-wise and member-wise reading modes based on this flag. This includes new logic to check expected streaming mode and throw errors if mismatched. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29R43-R44) [[2]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aR196-R239) [[3]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL242-R363) [[4]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL291-R441)
* Introduced new methods `read_many_memberwise` and refactored `read` methods to `read_many` and `read_until` for clarity and consistency across all element readers, with improved error handling for negative counts. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29R190-R197) [[2]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L203-R215) [[3]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aR145-R179) [[4]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL291-R441) [[5]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL370-R480) [[6]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL402-R512)
* Refactored composite reader classes: replaced `NBytesVersionReader` and old `GroupReader` with a new `GroupReader` and an `AnyClassReader`, separating their responsibilities and improving error checking for read lengths.
* Updated constructors of STL and composite readers to accept a streaming mode flag (`objwise_or_memberwise`) instead of a boolean, allowing auto-detection or explicit mode selection. [[1]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aR196-R239) [[2]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL242-R363)
* Minor improvement: included `<sstream>` for error message construction and improved debug output throughout the reading logic. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29R13) [[2]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aR196-R239) [[3]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL463-R669)

These changes make the codebase more robust in handling different ROOT streaming formats and lay the groundwork for future extensions and maintenance.