### PR TITLE
Fix pattern of `_item_any_pattern` to fix `get_dims_from_branch`

### DIFF
--- a/example/cpp/CMakeLists.txt
+++ b/example/cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ project(${SKBUILD_PROJECT_NAME}
     VERSION ${SKBUILD_PROJECT_VERSION}
     LANGUAGES CXX
 )
-    
+
 set(PYBIND11_NEWPYTHON ON)
 find_package(pybind11 REQUIRED)
 find_package(uproot-custom REQUIRED)

--- a/uproot_custom/utils.py
+++ b/uproot_custom/utils.py
@@ -11,7 +11,7 @@ def regularize_object_path(object_path: str) -> str:
 
 _title_has_dims = re.compile(r"^([^\[\]]*)(\[[^\[\]]+\])+")
 _item_dim_pattern = re.compile(r"\[([1-9][0-9]*)\]")
-_item_any_pattern = re.compile(r"\[(.*)\]")
+_item_any_pattern = re.compile(r"(\[.*\])")
 
 
 def get_dims_from_branch(


### PR DESCRIPTION
This pull request makes a small change to the regular expression used in the `_item_any_pattern` variable within `uproot_custom/utils.py`. The updated pattern now captures the entire bracketed expression, which may improve how object paths are parsed.