### PR TITLE
Fix githut-action deploy-docs [skip ci]

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,8 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             pip install .[docs]
-            apt install -y doxygen
+            sudo apt-get update
+            sudo apt-get install -y doxygen
 
         - name: Build docs
           run: |


### PR DESCRIPTION
This pull request makes a small update to the documentation deployment workflow by ensuring that `doxygen` is installed before building the docs.

* Added steps to update the package list and install `doxygen` using `apt-get` in the `.github/workflows/deploy-docs.yml` workflow.

[skip ci]