### PR TITLE
chore: add segmantic-pr-titles action [skip ci]

### DIFF
--- a/.github/workflows/semantic-pr-titles.yml
+++ b/.github/workflows/semantic-pr-titles.yml
@@ -1,0 +1,19 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce semantic pull request titles. The workflow is triggered whenever a pull request is opened, edited, or reopened, and uses an external action to validate the PR title format.

**Continuous Integration Improvements:**

* Added a new workflow file `.github/workflows/semantic-pr-titles.yml` to automatically lint PR titles for semantic correctness using the `amannn/action-semantic-pull-request` action.