### PR TITLE
chore: add `nightly-build` action

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,10 @@
+name: Nightly build
+
+on:
+  schedule:
+    - cron: '12 0 * * *'  # Runs every day at 20:00 Beijing time
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/build-wheels.yml


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate nightly builds. The workflow is scheduled to run every day at 20:00 Beijing time and can also be triggered manually.

Continuous integration improvements:

* Added a new `.github/workflows/nightly-build.yml` workflow that schedules nightly builds and allows manual triggering, reusing the existing `build-wheels.yml` workflow.