### PR TITLE
chore: Remove unused dependencies in `dev` group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,6 @@ classifiers = [
 optional-dependencies = { "dev" = [
     "pytest",
     "pytest-xdist",
-    "dask[complete]",
-    "dask-awkward",
     "build",
 ], "docs" = [
     "sphinx>=8.2",


### PR DESCRIPTION
This pull request makes a minor update to the development dependencies in the `pyproject.toml` file, removing two unnecessary packages.

* Removed `dask[complete]` and `dask-awkward` from the `dev` optional dependencies in `pyproject.toml` to streamline the development environment.