### PR TITLE
perf: Optimize performance of python reader

### DIFF
--- a/uproot_custom/readers/python.py
+++ b/uproot_custom/readers/python.py
@@ -31,7 +31,7 @@ class BinaryBuffer:
         offsets: NDArray[np.uint32],
         repr_nbytes: int = 50,
     ):
-        self.data = data
+        self.data = data.tobytes()
         self.offsets = offsets
         self.cursor = 0
         self.repr_nbytes = repr_nbytes
@@ -45,52 +45,52 @@ class BinaryBuffer:
         return self.data[self.cursor :]
 
     def read_uint8(self) -> int:
-        val = struct.unpack_from(">B", self.remaining_data)[0]
+        val = struct.unpack_from(">B", self.data, self.cursor)[0]
         self.cursor += 1
         return val
 
     def read_uint16(self) -> int:
-        val = struct.unpack_from(">H", self.remaining_data)[0]
+        val = struct.unpack_from(">H", self.data, self.cursor)[0]
         self.cursor += 2
         return val
 
     def read_uint32(self) -> int:
-        val = struct.unpack_from(">I", self.remaining_data)[0]
+        val = struct.unpack_from(">I", self.data, self.cursor)[0]
         self.cursor += 4
         return val
 
     def read_uint64(self) -> int:
-        val = struct.unpack_from(">Q", self.remaining_data)[0]
+        val = struct.unpack_from(">Q", self.data, self.cursor)[0]
         self.cursor += 8
         return val
 
     def read_int8(self) -> int:
-        val = struct.unpack_from(">b", self.remaining_data)[0]
+        val = struct.unpack_from(">b", self.data, self.cursor)[0]
         self.cursor += 1
         return val
 
     def read_int16(self) -> int:
-        val = struct.unpack_from(">h", self.remaining_data)[0]
+        val = struct.unpack_from(">h", self.data, self.cursor)[0]
         self.cursor += 2
         return val
 
     def read_int32(self) -> int:
-        val = struct.unpack_from(">i", self.remaining_data)[0]
+        val = struct.unpack_from(">i", self.data, self.cursor)[0]
         self.cursor += 4
         return val
 
     def read_int64(self) -> int:
-        val = struct.unpack_from(">q", self.remaining_data)[0]
+        val = struct.unpack_from(">q", self.data, self.cursor)[0]
         self.cursor += 8
         return val
 
     def read_float(self) -> float:
-        val = struct.unpack_from(">f", self.remaining_data)[0]
+        val = struct.unpack_from(">f", self.data, self.cursor)[0]
         self.cursor += 4
         return val
 
     def read_double(self) -> float:
-        val = struct.unpack_from(">d", self.remaining_data)[0]
+        val = struct.unpack_from(">d", self.data, self.cursor)[0]
         self.cursor += 8
         return val
 


### PR DESCRIPTION
This pull request updates the way binary data is handled in the `uproot_custom/readers/python.py` file. The main change is that the internal representation of the data is now always stored as a bytes object, and all struct unpacking operations are performed directly on this bytes data using the current cursor position. This makes the code more efficient and avoids repeatedly slicing the data for each read operation.

**Improvements to data handling and efficiency:**

* In the class initializer, `self.data` is now set to `data.tobytes()`, ensuring the internal data is always stored as bytes.
* All read methods (`read_uint8`, `read_uint16`, `read_uint32`, `read_uint64`, `read_int8`, `read_int16`, `read_int32`, `read_int64`, `read_float`, `read_double`) now use `struct.unpack_from` directly on `self.data` at `self.cursor`, rather than unpacking from a sliced view of the data. This avoids unnecessary data copying and improves efficiency.