### PR TITLE
chore: Add template for github release changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: C++ API Changes
+      labels:
+        - break cpp
+    - title: New Features
+      labels:
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Performance Improvements
+      labels:
+        - performance
+    - title: Other Changes
+      labels:
+        - '*'


### PR DESCRIPTION
This pull request introduces a changelog configuration to the release workflow, categorizing changes by their type for clearer release notes.

Changelog configuration updates:

* Added a `changelog` section to `.github/release.yml` that organizes release notes into categories such as "C++ API Changes", "New Features", "Bug Fixes", "Performance Improvements", and "Other Changes", based on associated labels.