### PR TITLE
refactor: Remove BoolReader and update related references to UInt8Reader

### DIFF
--- a/cpp/src/uproot-custom.cc
+++ b/cpp/src/uproot-custom.cc
@@ -52,35 +52,6 @@ namespace uproot {
         py::object data() const override { return make_array( m_data ); }
     };
 
-    /**
-     * @brief Specialization of PrimitiveReader for bool type. Bools are stored as uint8_t.
-     */
-    template <>
-    class PrimitiveReader<bool> : public IReader {
-      private:
-        SharedVector<uint8_t> m_data; ///< Store the read data as uint8_t
-
-      public:
-        PrimitiveReader( string name )
-            : IReader( name ), m_data( std::make_shared<vector<uint8_t>>() ) {}
-
-        /**
-         * @brief Read a uint8_t from the buffer and store it as bool
-         *
-         * @param buffer The binary buffer to read from
-         */
-        void read( BinaryBuffer& buffer ) override {
-            m_data->push_back( buffer.read<uint8_t>() != 0 );
-        }
-
-        /**
-         * @brief Get the read data as a numpy array
-         *
-         * @return Numpy array containing the read data
-         */
-        py::object data() const override { return make_array( m_data ); }
-    };
-
     /*
     -----------------------------------------------------------------------------
     -----------------------------------------------------------------------------
@@ -1276,7 +1247,6 @@ namespace uproot {
         declare_reader<PrimitiveReader<int64_t>, string>( m, "Int64Reader" );
         declare_reader<PrimitiveReader<float>, string>( m, "FloatReader" );
         declare_reader<PrimitiveReader<double>, string>( m, "DoubleReader" );
-        declare_reader<PrimitiveReader<bool>, string>( m, "BoolReader" );
 
         // STL readers
         declare_reader<STLSeqReader, string, bool, int, SharedReader>( m, "STLSeqReader" );

--- a/uproot_custom/cpp.pyi
+++ b/uproot_custom/cpp.pyi
@@ -36,9 +36,6 @@ class Int32Reader(IReader):
 class Int64Reader(IReader):
     def __init__(self, name: str) -> None: ...
 
-class BoolReader(IReader):
-    def __init__(self, name: str) -> None: ...
-
 class DoubleReader(IReader):
     def __init__(self, name: str) -> None: ...
 

--- a/uproot_custom/factories.py
+++ b/uproot_custom/factories.py
@@ -341,7 +341,7 @@ class PrimitiveFactory(Factory):
     }
 
     cpp_reader_map = {
-        "bool": uproot_custom.readers.cpp.BoolReader,
+        "bool": uproot_custom.readers.cpp.UInt8Reader,
         "int8": uproot_custom.readers.cpp.Int8Reader,
         "int16": uproot_custom.readers.cpp.Int16Reader,
         "int32": uproot_custom.readers.cpp.Int32Reader,

--- a/uproot_custom/readers/cpp.py
+++ b/uproot_custom/readers/cpp.py
@@ -6,7 +6,6 @@ This file contains only type hints without implementations.
 
 from uproot_custom.cpp import (
     AnyClassReader,
-    BoolReader,
     CStyleArrayReader,
     DoubleReader,
     EmptyReader,
@@ -38,7 +37,6 @@ from uproot_custom.cpp import (
 
 __all__ = [
     "AnyClassReader",
-    "BoolReader",
     "CStyleArrayReader",
     "DoubleReader",
     "EmptyReader",


### PR DESCRIPTION
This pull request removes the custom `BoolReader` implementation from both the C++ and Python codebases, and updates the factory logic to use `UInt8Reader` for boolean types instead. This simplifies the codebase by treating booleans as uint8 values, aligning with how they are stored internally.

### Removal of custom boolean reader:

* Removed the specialization of `PrimitiveReader<bool>` (previously known as `BoolReader`) from the C++ code, including its registration with Python bindings (`cpp/src/uproot-custom.cc`). [[1]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL55-L83) [[2]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL1279)
* Removed the `BoolReader` class from the Python type stubs (`uproot_custom/cpp.pyi`).
* Removed all imports and references to `BoolReader` in the Python reader module (`uproot_custom/readers/cpp.py`). [[1]](diffhunk://#diff-014c02db8c878b9b6b134002eec5a74077463c1caff104bf0e82285b6604d7faL9) [[2]](diffhunk://#diff-014c02db8c878b9b6b134002eec5a74077463c1caff104bf0e82285b6604d7faL41)

### Factory and mapping updates:

* Updated the `PrimitiveFactory` mapping to use `UInt8Reader` for the `"bool"` type instead of the now-removed `BoolReader` (`uproot_custom/factories.py`).