### PR TITLE
docs: Update system requirements for C++17 compatibility in README and version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ This mechanism is implemented as `AsCustom` interpretation. This makes uproot-cu
 > [!NOTE]
 > Uproot-custom does not provide a full reimplementation of `ROOT`'s TTree I/O system. Users are expected to implement their own Factory / Reader for their custom classes that built-in factories cannot handle.
 
+## System Requirements
+
+- **C++17 compatible compiler**: Required for building C++ readers and the uproot-custom extension module. The CMake configuration sets `CMAKE_CXX_STANDARD 17`.
+- **Python 3.9+**: Uproot-custom supports Python 3.9 through 3.13.
+
 ## Documentation
 
 View the [documentation](https://mrzimu.github.io/uproot-custom/) for more details about customizing your own `reader`/`factory`, the architecture of uproot-custom, and build-only dependencies (e.g., `pybind11` is needed only at build time and should not be present in the runtime environment).

--- a/docs/reference/version-requirements.md
+++ b/docs/reference/version-requirements.md
@@ -6,6 +6,16 @@ Uproot-custom guarantees C++ header compatibility within a minor version (for
 example, `2.0.0` and `2.0.1` headers are compatible). Pin the minor version in
 your `pyproject.toml` to avoid surprises when rebuilding readers.
 
+## C++ compiler requirement
+
+Uproot-custom and user‑implemented C++ readers require a **C++17 compatible compiler**.
+The CMake configuration sets `CMAKE_CXX_STANDARD 17`. Ensure your compiler
+supports C++17 features such as structured bindings, `std::optional`, and
+`std::variant`.
+
+If you are building on an older system, you may need to upgrade your compiler
+(e.g., GCC ≥ 7, Clang ≥ 5, MSVC ≥ 19.15) or adjust the CMake flags accordingly.
+
 ## pybind11 version requirement
 
 `pybind11` is a **build-time dependency only**. Do not ship or import

--- a/docs/tutorial/customize-factory-reader.md
+++ b/docs/tutorial/customize-factory-reader.md
@@ -30,7 +30,8 @@ class: note
 ---
 - A Python toolchain capable of building Python packages (e.g. `pip`,
   `setuptools`, `scikit-build-core`)
-- (Optional, for C++ backend) A C++17 compiler and CMake ≥ 3.20
+- **C++17 compatible compiler** (e.g., GCC ≥ 7, Clang ≥ 5, MSVC ≥ 19.15) for building C++ readers
+- CMake ≥ 3.20 for building native extensions
 ```
 
 ## Tutorial roadmap


### PR DESCRIPTION
This pull request improves the documentation for system and compiler requirements, clarifying what is needed to build and use C++ readers and the uproot-custom extension. The changes make it easier for users to understand the necessary tools and versions before getting started.

**Documentation updates for system and compiler requirements:**

* Added a "System Requirements" section to the `README.md`, specifying the need for a C++17 compatible compiler and Python 3.9+ for building and using uproot-custom.
* Expanded the `version-requirements.md` documentation to detail the C++17 compiler requirement, including examples of supported compilers and relevant CMake settings.
* Updated the tutorial prerequisites to explicitly mention the need for a C++17 compatible compiler (with version examples) and clarified the CMake version requirement.