### PR TITLE
docs: Add warning about v2.x.x series being a development version in README and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Uproot-custom is an extension of [Uproot](https://uproot.readthedocs.io/en/latest/basic.html) that provides an enhanced way to read custom classes stored in `TTree`.
 
+> [!WARNING]
+> Because of earlier mistakes in version management, the `v2.x.x` series should still be treated as a development version rather than a stable release.
+
 ## What uproot-custom can do
 
 Uproot-custom can natively read complicated combinations of nested classes and c-style arrays (e.g. `map<int, map<int, map<int, string>>>`, `vector<TString>[3]`, etc), and memberwisely stored classes. It also exposes a way for users to implement their own readers for custom classes that are not supported by Uproot or uproot-custom built-in readers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 Uproot-custom is an extension of [Uproot](https://uproot.readthedocs.io/en/latest/basic.html) that provides an enhanced way to read custom classes stored in `TTree`.
 
+```{important}
+Because of earlier mistakes in version management, the `v2.x.x` series should still be treated as a development version rather than a stable release.
+```
+
 ## What uproot-custom can do
 
 Uproot-custom can natively read complicated combinations of nested classes and c-style arrays (e.g. `map<int, map<int, map<int, string>>>`, `vector<TString>[3]`, etc), and memberwisely stored classes. It also exposes a way for users to implement their own readers for custom classes that are not supported by Uproot or uproot-custom built-in readers.


### PR DESCRIPTION
This pull request updates the project documentation to clarify the status of the `v2.x.x` release series. It adds a prominent warning to both the `README.md` and the documentation index, indicating that this version should still be considered a development version due to earlier version management mistakes.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R7): Added a warning block to alert users that the `v2.x.x` series is not yet a stable release.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R5-R8): Added an "important" admonition with the same warning about the development status of the `v2.x.x` series.