### PR TITLE
docs: Update pybind11 version requirement

### DIFF
--- a/docs/reference/version-requirements.md
+++ b/docs/reference/version-requirements.md
@@ -47,6 +47,4 @@ This table summarizes the required `pybind11` versions for each uproot-custom ve
 
 | uproot-custom | pybind11 |
 | :-----------: | :------: |
-| `2.0`         | `3.0.*`  |
-| `2.1`         | `3.0.*`  |
-| `2.2`		    | `3.0.*`  |
+| `2.*`         | `3.0.*`  |

--- a/uproot_custom/factories.py
+++ b/uproot_custom/factories.py
@@ -1501,7 +1501,7 @@ class ObjectHeaderFactory(Factory):
 
         warnings.warn(
             "ObjectHeaderFactory is deprecated and will be removed in future versions. "
-            "Please use AnyPointerFactory nstead.",
+            "Please use AnyPointerFactory instead.",
             FutureWarning,
         )
 


### PR DESCRIPTION
This pull request makes minor updates to documentation and code comments for clarity and correctness. The changes include correcting a typo in a deprecation warning and simplifying the version requirements table in the documentation.

Documentation updates:

* Simplified the `pybind11` version requirements table in `docs/reference/version-requirements.md` by merging all `uproot-custom` 2.x versions into a single row, indicating that all `2.*` versions require `pybind11` version `3.0.*`.

Code comment improvements:

* Fixed a typo in the deprecation warning message in `uproot_custom/factories.py` by correcting "nstead" to "instead".