### PR TITLE
refactor: rename `BinaryBuffer` to `BinaryStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ flowchart TD
     raw_data --> build_ak
 ```
 
-- `Reader` is a class that implements the logic to read data from binary buffers. It can be written in **Python** (for development and debugging) or **C++** (for production performance).
+- `Reader` is a class that implements the logic to read data from binary streams. It can be written in **Python** (for development and debugging) or **C++** (for production performance).
 - `Factory` is a Python class that creates, combines `Reader`s, and post-processes the data read by `Reader`s.
 
 This mechanism is implemented as `AsCustom` interpretation. This makes uproot-custom well compatible with Uproot.

--- a/cpp/include/uproot-custom/uproot-custom.hh
+++ b/cpp/include/uproot-custom/uproot-custom.hh
@@ -47,7 +47,7 @@ namespace uproot {
 
     const uint16_t kStreamedMemberWise = 1 << 14; // streamed member-wise mask
 
-    class BinaryBuffer {
+    class BinaryStream {
       public:
         enum EStatusBits {
             kCanDelete = 1ULL << 0, ///< if object in a list can be deleted
@@ -75,11 +75,11 @@ namespace uproot {
         using Reference = std::variant<RefCls, RefObj>;
 
         /**
-         * @brief Construct a BinaryBuffer from numpy arrays.
+         * @brief Construct a BinaryStream from numpy arrays.
          * @param data A numpy array of uint8_t containing the raw data.
          * @param offsets A numpy array of uint32_t containing the offsets for each entry.
          */
-        BinaryBuffer( py::array_t<uint8_t> data, py::array_t<uint32_t> offsets,
+        BinaryStream( py::array_t<uint8_t> data, py::array_t<uint32_t> offsets,
                       uint32_t initial_cursor_position )
             : m_data( static_cast<uint8_t*>( data.request().ptr ) )
             , m_offsets( static_cast<uint32_t*>( offsets.request().ptr ) )
@@ -88,10 +88,10 @@ namespace uproot {
             , m_cursor( static_cast<uint8_t*>( data.request().ptr ) ) {}
 
         /**
-         * @brief Read a value of type T from the buffer, handling endianness.
+         * @brief Read a value of type T from the stream, handling endianness.
          *
          * @tparam T The type to read.
-         * @return The value read from the buffer.
+         * @return The value read from the stream.
          */
         template <typename T>
         const T read() {
@@ -136,14 +136,14 @@ namespace uproot {
         }
 
         /**
-         * @brief Read the fVersion field from the buffer
+         * @brief Read the fVersion field from the stream
          *
          * @return The fVersion value
          */
         const int16_t read_fVersion() { return read<int16_t>(); }
 
         /**
-         * @brief Read the fNBytes field from the buffer, checking the byte count mask.
+         * @brief Read the fNBytes field from the stream, checking the byte count mask.
          *
          * @return The fNBytes value without the mask.
          * @exception std::runtime_error if the byte count mask is not set.
@@ -156,9 +156,9 @@ namespace uproot {
         }
 
         /**
-         * @brief Read a null-terminated (`\0`) string from the buffer.
+         * @brief Read a null-terminated (`\0`) string from the stream.
          *
-         * @return The string read from the buffer.
+         * @return The string read from the stream.
          */
         const std::string read_null_terminated_string() {
             auto start = m_cursor;
@@ -168,7 +168,7 @@ namespace uproot {
         }
 
         /**
-         * @brief Read an object header from the buffer. The object header has `fNBytes`,
+         * @brief Read an object header from the stream. The object header has `fNBytes`,
          * `fVersion`, `fTag`. If `fTag == kNewClassTag`, then a null-terminated class name
          * follows.
          *
@@ -183,11 +183,11 @@ namespace uproot {
         }
 
         /**
-         * @brief Read a TString from the buffer. A TString has `length` (uint8_t). If `length
+         * @brief Read a TString from the stream. A TString has `length` (uint8_t). If `length
          * == 255`, then the `length` is a following uint32_t. Then following `length` bytes of
          * string data.
          *
-         * @return The TString data read from the buffer, as a std::string.
+         * @return The TString data read from the stream, as a std::string.
          */
         const std::string read_TString() {
             uint32_t length = read<uint8_t>();
@@ -198,7 +198,7 @@ namespace uproot {
         }
 
         /**
-         * @brief Skip `n` bytes in the buffer.
+         * @brief Skip `n` bytes in the stream.
          *
          * @param n Number of bytes to skip.
          */
@@ -216,7 +216,7 @@ namespace uproot {
         void skip_fVersion() { skip( 2 ); }
 
         /**
-         * @brief Skip a null-terminated (`\0`) string in the buffer.
+         * @brief Skip a null-terminated (`\0`) string in the stream.
          */
         void skip_null_terminated_string() {
             while ( *m_cursor != 0 ) { m_cursor++; }
@@ -224,7 +224,7 @@ namespace uproot {
         }
 
         /**
-         * @brief Skip an object header in the buffer. The object header has `fNBytes`,
+         * @brief Skip an object header in the stream. The object header has `fNBytes`,
          * `fVersion`, `fTag`. If `fTag == kNewClassTag`, then a null-terminated class name
          * follows.
          */
@@ -235,7 +235,7 @@ namespace uproot {
         }
 
         /**
-         * @brief Skip a TObject in the buffer. A TObject has `fVersion` (2 bytes), `fUniqueID`
+         * @brief Skip a TObject in the stream. A TObject has `fVersion` (2 bytes), `fUniqueID`
          * (4 bytes), `fBits` (4 bytes). If `fBits & kIsReferenced`, then a `pidf` (2 bytes)
          * follows.
          */
@@ -311,6 +311,11 @@ namespace uproot {
                                               ///< reading
     };
 
+    // backward compatibility
+    using BinaryBuffer
+        [[deprecated( "BinaryBuffer is deprecated. Use BinaryStream instead." )]] =
+            BinaryStream;
+
     /*
     -----------------------------------------------------------------------------
     -----------------------------------------------------------------------------
@@ -342,11 +347,11 @@ namespace uproot {
         virtual const std::string name() const { return m_name; }
 
         /**
-         * @brief Read an element from the buffer.
+         * @brief Read an element from the stream.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        virtual void read( BinaryBuffer& buffer ) = 0;
+        virtual void read( BinaryStream& stream ) = 0;
 
         /**
          * @brief Get the data read by the reader. This should be called after the whole
@@ -357,53 +362,53 @@ namespace uproot {
         virtual py::object data() const = 0;
 
         /**
-         * @brief Read multiple elements from the buffer in one go. Repeatedly calls @ref
+         * @brief Read multiple elements from the stream in one go. Repeatedly calls @ref
          * read() by default.
          *
          * @note When multiple elements are stored together, some classes may have "one common
          * header + multiple data objects" format. This method can be overridden to handle such
          * cases more efficiently.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of elements to read.
          * @return Number of elements read.
          */
-        virtual uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) {
-            for ( int32_t i = 0; i < count; i++ ) { read( buffer ); }
+        virtual uint32_t read_many( BinaryStream& stream, const int64_t count ) {
+            for ( int32_t i = 0; i < count; i++ ) { read( stream ); }
             return count;
         }
 
         /**
-         * @brief Read elements from the buffer until reaching the end position. Repeatedly
+         * @brief Read elements from the stream until reaching the end position. Repeatedly
          * calls @ref read() method by default.
          *
          * @note When multiple elements are stored together, some classes may have "one common
          * header + multiple data objects" format. This method can be overridden to handle such
          * cases more efficiently.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param end_pos The end position pointer.
          * @return Number of elements read.
          */
-        virtual uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) {
+        virtual uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) {
             uint32_t cur_count = 0;
-            while ( buffer.get_cursor() < end_pos )
+            while ( stream.get_cursor() < end_pos )
             {
-                read( buffer );
+                read( stream );
                 cur_count++;
             }
             return cur_count;
         }
 
         /**
-         * @brief Read multiple elements from the buffer in member-wise fashion. Readers
+         * @brief Read multiple elements from the stream in member-wise fashion. Readers
          * that need to handle member-wise data reading must implement this method.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of elements to read.
          * @return Number of elements read.
          */
-        virtual uint32_t read_many_memberwise( BinaryBuffer& buffer, const int64_t count ) {
+        virtual uint32_t read_many_memberwise( BinaryStream& stream, const int64_t count ) {
             throw std::runtime_error( name() + "::read_many_memberwise is not implemented." );
         }
     };
@@ -509,20 +514,20 @@ namespace uproot {
     }
 
     /**
-     * @brief Debug print function for BinaryBuffer. Prints only when macro or environment
-     * varialbe with name `UPROOT_DEBUG` is defined. Call @ref BinaryBuffer::debug_print()
+     * @brief Debug print function for BinaryStream. Prints only when macro or environment
+     * varialbe with name `UPROOT_DEBUG` is defined. Call @ref BinaryStream::debug_print()
      * internally.
      *
-     * @param buffer The BinaryBuffer to print.
+     * @param stream The BinaryStream to print.
      * @param n Number of bytes to print.
      */
-    inline void debug_printf( uproot::BinaryBuffer& buffer, const size_t n = 100 ) {
+    inline void debug_printf( uproot::BinaryStream& stream, const size_t n = 100 ) {
         bool do_print = getenv( "UPROOT_DEBUG" );
 #ifdef UPROOT_DEBUG
         do_print = true;
 #endif
         if ( !do_print ) return;
-        buffer.debug_print( n );
+        stream.debug_print( n );
     }
 
 } // namespace uproot

--- a/cpp/include/uproot-custom/uproot-custom.hh
+++ b/cpp/include/uproot-custom/uproot-custom.hh
@@ -515,7 +515,7 @@ namespace uproot {
 
     /**
      * @brief Debug print function for BinaryStream. Prints only when macro or environment
-     * varialbe with name `UPROOT_DEBUG` is defined. Call @ref BinaryStream::debug_print()
+     * variable with name `UPROOT_DEBUG` is defined. Call @ref BinaryStream::debug_print()
      * internally.
      *
      * @param stream The BinaryStream to print.

--- a/cpp/src/uproot-custom.cc
+++ b/cpp/src/uproot-custom.cc
@@ -42,11 +42,11 @@ namespace uproot {
             : IReader( name ), m_data( std::make_shared<vector<T>>() ) {}
 
         /**
-         * @brief Read a value from the buffer and store it. Only reads one value at a time.
+         * @brief Read a value from the stream and store it. Only reads one value at a time.
          *
-         * @param buffer The binary buffer to read from
+         * @param stream The binary stream to read from
          */
-        void read( BinaryBuffer& buffer ) override { m_data->push_back( buffer.read<T>() ); }
+        void read( BinaryStream& stream ) override { m_data->push_back( stream.read<T>() ); }
 
         /**
          * @brief Get the read data as a numpy array
@@ -89,22 +89,22 @@ namespace uproot {
             , m_pidf_offsets( std::make_shared<vector<int64_t>>( 1, 0 ) ) {}
 
         /**
-         * @brief Read a TObject from the buffer. A TObject contains `fVersion` (int16_t),
+         * @brief Read a TObject from the stream. A TObject contains `fVersion` (int16_t),
          * `fUniqueID` (int32_t), `fBits` (uint32_t). If `fBits & kIsReferenced`, then a `pidf`
          * (uint16_t) follows. If @ref m_keep_data is true, the read data
          * will be stored.
          *
-         * @param buffer The binary buffer to read from
+         * @param stream The binary stream to read from
          */
-        void read( BinaryBuffer& buffer ) override {
-            buffer.skip_fVersion();
-            auto fUniqueID = buffer.read<int32_t>();
-            auto fBits     = buffer.read<uint32_t>();
+        void read( BinaryStream& stream ) override {
+            stream.skip_fVersion();
+            auto fUniqueID = stream.read<int32_t>();
+            auto fBits     = stream.read<uint32_t>();
 
-            if ( fBits & ( BinaryBuffer::kIsReferenced ) )
+            if ( fBits & ( BinaryStream::kIsReferenced ) )
             {
-                if ( m_keep_data ) m_pidf->push_back( buffer.read<uint16_t>() );
-                else buffer.skip( 2 );
+                if ( m_keep_data ) m_pidf->push_back( stream.read<uint16_t>() );
+                else stream.skip( 2 );
             }
 
             if ( m_keep_data )
@@ -162,29 +162,29 @@ namespace uproot {
             , m_offsets( std::make_shared<vector<int64_t>>( 1, 0 ) ) {}
 
         /**
-         * @brief Read a TString from the buffer. A TString starts with a uint8_t size. If the
+         * @brief Read a TString from the stream. A TString starts with a uint8_t size. If the
          * size is 255, then a uint32_t size follows. Then the string data follows. It @ref
          * m_with_header is true, read a `fNBytes+fVersion` header before reading the TString.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
-            uint32_t fSize = buffer.read<uint8_t>();
-            if ( fSize == 255 ) fSize = buffer.read<uint32_t>();
+        void read( BinaryStream& stream ) override {
+            uint32_t fSize = stream.read<uint8_t>();
+            if ( fSize == 255 ) fSize = stream.read<uint32_t>();
 
-            for ( int i = 0; i < fSize; i++ ) { m_data->push_back( buffer.read<uint8_t>() ); }
+            for ( int i = 0; i < fSize; i++ ) { m_data->push_back( stream.read<uint8_t>() ); }
             m_offsets->push_back( m_data->size() );
         }
 
         /**
-         * @brief Read multiple TStrings from the buffer. If @ref m_with_header is true, only
+         * @brief Read multiple TStrings from the stream. If @ref m_with_header is true, only
          * read `fNBytes+fVersion` header once before reading multiple TStrings.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of TStrings to read. If negative, throws an error.
          * @return Number of TStrings read.
          */
-        uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many( BinaryStream& stream, const int64_t count ) override {
             if ( count < 0 )
                 throw std::runtime_error(
                     "TStringReader::read_many with negative count not supported!" );
@@ -193,36 +193,36 @@ namespace uproot {
 
             if ( m_with_header )
             {
-                auto fNBytes  = buffer.read_fNBytes();
-                auto fVersion = buffer.read_fVersion();
+                auto fNBytes  = stream.read_fNBytes();
+                auto fVersion = stream.read_fVersion();
             }
 
-            for ( auto i = 0; i < count; i++ ) { read( buffer ); }
+            for ( auto i = 0; i < count; i++ ) { read( stream ); }
             return count;
         }
 
         /**
-         * @brief Read TStrings from the buffer until reaching the end position. If @ref
+         * @brief Read TStrings from the stream until reaching the end position. If @ref
          * m_with_header is true, only read `fNBytes+fVersion` header once before reading
          * TStrings.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param end_pos The end position to stop reading.
          * @return Number of TStrings read.
          */
-        uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) override {
-            if ( buffer.get_cursor() == end_pos ) return 0;
+        uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) override {
+            if ( stream.get_cursor() == end_pos ) return 0;
 
             if ( m_with_header )
             {
-                auto fNBytes  = buffer.read_fNBytes();
-                auto fVersion = buffer.read_fVersion();
+                auto fNBytes  = stream.read_fNBytes();
+                auto fVersion = stream.read_fVersion();
             }
 
             uint32_t cur_count = 0;
-            while ( buffer.get_cursor() < end_pos )
+            while ( stream.get_cursor() < end_pos )
             {
-                read( buffer );
+                read( stream );
                 cur_count++;
             }
             return cur_count;
@@ -290,62 +290,62 @@ namespace uproot {
         }
 
         /**
-         * @brief Read the element version and checksum from the buffer.
+         * @brief Read the element version and checksum from the stream.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @return A tuple of (version, checksum).
          */
-        pair<int, uint32_t> read_element_version( BinaryBuffer& buffer ) {
-            auto version      = buffer.read_fVersion();
+        pair<int, uint32_t> read_element_version( BinaryStream& stream ) {
+            auto version      = stream.read_fVersion();
             uint32_t checksum = 0;
-            if ( version == 0 ) checksum = buffer.read<uint32_t>();
+            if ( version == 0 ) checksum = stream.read<uint32_t>();
             return { version, checksum };
         }
 
         /**
-         * @brief Read the body of the sequence from the buffer. First reads the size
+         * @brief Read the body of the sequence from the stream. First reads the size
          * (uint32_t) of the sequence, then calls @ref m_element_reader to read the elements.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param is_memberwise Whether the current reading mode is member-wise.
          */
-        void read_body( BinaryBuffer& buffer, bool is_memberwise ) {
-            auto fSize = buffer.read<uint32_t>();
+        void read_body( BinaryStream& stream, bool is_memberwise ) {
+            auto fSize = stream.read<uint32_t>();
             m_offsets->push_back( m_offsets->back() + fSize );
 
             debug_printf( "STLSeqReader(%s): reading body, is_memberwise=%d, fSize=%d\n",
                           m_name.c_str(), is_memberwise, fSize );
-            debug_printf( buffer );
+            debug_printf( stream );
 
-            if ( is_memberwise ) m_element_reader->read_many_memberwise( buffer, fSize );
-            else m_element_reader->read_many( buffer, fSize );
+            if ( is_memberwise ) m_element_reader->read_many_memberwise( stream, fSize );
+            else m_element_reader->read_many( stream, fSize );
         }
 
         /**
-         * @brief Read a sequence from the buffer. If @ref m_with_header is true, reads a
+         * @brief Read a sequence from the stream. If @ref m_with_header is true, reads a
          * `fNBytes+fVersion` header. Then calls @ref read_body() to read the sequence body.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
-            buffer.read_fNBytes();
-            auto fVersion      = buffer.read_fVersion();
+        void read( BinaryStream& stream ) override {
+            stream.read_fNBytes();
+            auto fVersion      = stream.read_fVersion();
             bool is_memberwise = fVersion & kStreamedMemberWise;
             check_objwise_memberwise( is_memberwise );
-            if ( is_memberwise ) read_element_version( buffer );
-            read_body( buffer, is_memberwise );
+            if ( is_memberwise ) read_element_version( stream );
+            read_body( stream, is_memberwise );
         }
 
         /**
-         * @brief Read multiple sequences from the buffer. If @ref m_with_header is true,
+         * @brief Read multiple sequences from the stream. If @ref m_with_header is true,
          * reads a `fNBytes+fVersion` header once before reading multiple sequences.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of sequences to read. If negative, reads according to the
          * `fNBytes` header.
          * @return Number of sequences read.
          */
-        uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many( BinaryStream& stream, const int64_t count ) override {
             if ( count == 0 ) return 0;
             else if ( count < 0 )
             {
@@ -353,17 +353,17 @@ namespace uproot {
                     throw std::runtime_error( "STLSeqReader::read with negative count only "
                                               "supported when with_header is true!" );
 
-                auto fNBytes       = buffer.read_fNBytes();
-                auto end_pos       = buffer.get_cursor() + fNBytes;
-                auto fVersion      = buffer.read_fVersion();
+                auto fNBytes       = stream.read_fNBytes();
+                auto end_pos       = stream.get_cursor() + fNBytes;
+                auto fVersion      = stream.read_fVersion();
                 bool is_memberwise = fVersion & kStreamedMemberWise;
                 check_objwise_memberwise( is_memberwise );
-                if ( is_memberwise ) read_element_version( buffer );
+                if ( is_memberwise ) read_element_version( stream );
 
                 uint32_t cur_count = 0;
-                while ( buffer.get_cursor() < end_pos )
+                while ( stream.get_cursor() < end_pos )
                 {
-                    read_body( buffer, is_memberwise );
+                    read_body( stream, is_memberwise );
                     cur_count++;
                 }
                 return cur_count;
@@ -373,43 +373,43 @@ namespace uproot {
                 bool is_memberwise = m_objwise_or_memberwise == 1;
                 if ( m_with_header )
                 {
-                    buffer.read_fNBytes();
-                    auto fVersion = buffer.read_fVersion();
+                    stream.read_fNBytes();
+                    auto fVersion = stream.read_fVersion();
                     is_memberwise = fVersion & kStreamedMemberWise;
                     check_objwise_memberwise( is_memberwise );
                 }
-                if ( is_memberwise ) read_element_version( buffer );
+                if ( is_memberwise ) read_element_version( stream );
 
-                for ( auto i = 0; i < count; i++ ) { read_body( buffer, is_memberwise ); }
+                for ( auto i = 0; i < count; i++ ) { read_body( stream, is_memberwise ); }
                 return count;
             }
         }
 
         /**
-         * @brief Read sequences from the buffer until reaching the end position. If @ref
+         * @brief Read sequences from the stream until reaching the end position. If @ref
          * m_with_header is true, reads a `fNBytes+fVersion` header once before reading
          * sequences. If data is stored member-wise, skips 2 bytes after the header.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param end_pos The end position to stop reading.
          * @return Number of sequences read.
          */
-        uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) override {
-            if ( buffer.get_cursor() == end_pos ) return 0;
+        uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) override {
+            if ( stream.get_cursor() == end_pos ) return 0;
             bool is_memberwise = m_objwise_or_memberwise == 1;
             if ( m_with_header )
             {
-                auto fNBytes  = buffer.read_fNBytes();
-                auto fVersion = buffer.read_fVersion();
+                auto fNBytes  = stream.read_fNBytes();
+                auto fVersion = stream.read_fVersion();
                 is_memberwise = fVersion & kStreamedMemberWise;
                 check_objwise_memberwise( is_memberwise );
             }
-            if ( is_memberwise ) read_element_version( buffer );
+            if ( is_memberwise ) read_element_version( stream );
 
             uint32_t cur_count = 0;
-            while ( buffer.get_cursor() < end_pos )
+            while ( stream.get_cursor() < end_pos )
             {
-                read_body( buffer, is_memberwise );
+                read_body( stream, is_memberwise );
                 cur_count++;
             }
             return cur_count;
@@ -474,74 +474,74 @@ namespace uproot {
         }
 
         /**
-         * @brief Read the element version and checksum from the buffer.
+         * @brief Read the element version and checksum from the stream.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @return A tuple of (version, checksum).
          */
-        pair<int, uint32_t> read_element_version( BinaryBuffer& buffer ) {
-            auto version      = buffer.read_fVersion();
+        pair<int, uint32_t> read_element_version( BinaryStream& stream ) {
+            auto version      = stream.read_fVersion();
             uint32_t checksum = 0;
-            if ( version == 0 ) checksum = buffer.read<uint32_t>();
+            if ( version == 0 ) checksum = stream.read<uint32_t>();
             return { version, checksum };
         }
 
         /**
-         * @brief Read the body of the map from the buffer. First reads the size
+         * @brief Read the body of the map from the stream. First reads the size
          * (uint32_t) of the map, then calls @ref m_key_reader and @ref m_value_reader
          * to read the keys and values. If member-wise, reads all keys first, then all values.
          * Otherwise, reads key-value pairs one by one.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param is_memberwise Whether the current reading mode is member-wise.
          */
-        void read_body( BinaryBuffer& buffer, bool is_memberwise ) {
-            auto fSize = buffer.read<uint32_t>();
+        void read_body( BinaryStream& stream, bool is_memberwise ) {
+            auto fSize = stream.read<uint32_t>();
             m_offsets->push_back( m_offsets->back() + fSize );
 
             if ( is_memberwise )
             {
-                m_key_reader->read_many( buffer, fSize );
-                m_value_reader->read_many( buffer, fSize );
+                m_key_reader->read_many( stream, fSize );
+                m_value_reader->read_many( stream, fSize );
             }
             else
             {
                 for ( auto i = 0; i < fSize; i++ )
                 {
-                    m_key_reader->read( buffer );
-                    m_value_reader->read( buffer );
+                    m_key_reader->read( stream );
+                    m_value_reader->read( stream );
                 }
             }
         }
 
         /**
-         * @brief Read a map from the buffer. Reads a `fNBytes+fVersion` header,
+         * @brief Read a map from the stream. Reads a `fNBytes+fVersion` header,
          * then reads element version/checksum via @ref read_element_version(), and
          * finally calls @ref read_body() to read the map body.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
-            buffer.read_fNBytes();
-            auto fVersion = buffer.read_fVersion();
-            read_element_version( buffer );
+        void read( BinaryStream& stream ) override {
+            stream.read_fNBytes();
+            auto fVersion = stream.read_fVersion();
+            read_element_version( stream );
 
             bool is_memberwise = fVersion & kStreamedMemberWise;
             check_objwise_memberwise( is_memberwise );
-            read_body( buffer, is_memberwise );
+            read_body( stream, is_memberwise );
         }
 
         /**
-         * @brief Read multiple maps from the buffer. If @ref m_with_header is true,
+         * @brief Read multiple maps from the stream. If @ref m_with_header is true,
          * reads a `fNBytes+fVersion` header and element version/checksum once before
          * reading multiple maps.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of maps to read. If negative, reads according to the
          * `fNBytes` header.
          * @return Number of maps read.
          */
-        uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many( BinaryStream& stream, const int64_t count ) override {
             if ( count == 0 ) return 0;
             else if ( count < 0 )
             {
@@ -549,18 +549,18 @@ namespace uproot {
                     throw std::runtime_error( "STLMapReader::read with negative count only "
                                               "supported when with_header is true!" );
 
-                auto fNBytes  = buffer.read_fNBytes();
-                auto fVersion = buffer.read_fVersion();
-                read_element_version( buffer );
+                auto fNBytes  = stream.read_fNBytes();
+                auto fVersion = stream.read_fVersion();
+                read_element_version( stream );
                 bool is_memberwise = fVersion & kStreamedMemberWise;
                 check_objwise_memberwise( is_memberwise );
 
-                auto end_pos = buffer.get_cursor() + fNBytes - 8;
+                auto end_pos = stream.get_cursor() + fNBytes - 8;
 
                 uint32_t cur_count = 0;
-                while ( buffer.get_cursor() < end_pos )
+                while ( stream.get_cursor() < end_pos )
                 {
-                    read_body( buffer, is_memberwise );
+                    read_body( stream, is_memberwise );
                     cur_count++;
                 }
                 return cur_count;
@@ -570,59 +570,59 @@ namespace uproot {
                 bool is_memberwise = m_objwise_or_memberwise == 1;
                 if ( m_with_header )
                 {
-                    auto fNBytes  = buffer.read_fNBytes();
-                    auto fVersion = buffer.read_fVersion();
-                    read_element_version( buffer );
+                    auto fNBytes  = stream.read_fNBytes();
+                    auto fVersion = stream.read_fVersion();
+                    read_element_version( stream );
 
                     is_memberwise = fVersion & kStreamedMemberWise;
                     check_objwise_memberwise( is_memberwise );
                 }
 
-                for ( auto i = 0; i < count; i++ ) { read_body( buffer, is_memberwise ); }
+                for ( auto i = 0; i < count; i++ ) { read_body( stream, is_memberwise ); }
                 return count;
             }
         }
 
         /**
-         * @brief Read maps from the buffer until reaching the end position. If @ref
+         * @brief Read maps from the stream until reaching the end position. If @ref
          * m_with_header is true, reads a `fNBytes+fVersion` header and element
          * version/checksum once before reading maps.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param end_pos The end position to stop reading.
          * @return Number of maps read.
          */
-        uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) override {
-            if ( buffer.get_cursor() == end_pos ) return 0;
+        uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) override {
+            if ( stream.get_cursor() == end_pos ) return 0;
 
             bool is_memberwise = m_objwise_or_memberwise == 1;
             if ( m_with_header )
             {
-                buffer.read_fNBytes();
-                auto fVersion = buffer.read_fVersion();
-                read_element_version( buffer );
+                stream.read_fNBytes();
+                auto fVersion = stream.read_fVersion();
+                read_element_version( stream );
 
                 is_memberwise = fVersion & kStreamedMemberWise;
                 check_objwise_memberwise( is_memberwise );
             }
 
             uint32_t cur_count = 0;
-            while ( buffer.get_cursor() < end_pos )
+            while ( stream.get_cursor() < end_pos )
             {
-                read_body( buffer, is_memberwise );
+                read_body( stream, is_memberwise );
                 cur_count++;
             }
             return cur_count;
         }
 
         /**
-         * @brief Read multiple maps from the buffer in member-wise mode.
+         * @brief Read multiple maps from the stream in member-wise mode.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of maps to read. If negative, throws an error.
          * @return Number of maps read.
          */
-        virtual uint32_t read_many_memberwise( BinaryBuffer& buffer,
+        virtual uint32_t read_many_memberwise( BinaryStream& stream,
                                                const int64_t count ) override {
             if ( count < 0 )
             {
@@ -633,7 +633,7 @@ namespace uproot {
 
             bool is_memberwise = true;
             check_objwise_memberwise( is_memberwise );
-            return read_many( buffer, count );
+            return read_many( stream, count );
         }
 
         /**
@@ -673,59 +673,59 @@ namespace uproot {
             , m_data( std::make_shared<vector<uint8_t>>() ) {}
 
         /**
-         * @brief Read the body of the string from the buffer. A string starts with a uint8_t
+         * @brief Read the body of the string from the stream. A string starts with a uint8_t
          * size. If the size is 255, then a uint32_t size follows. Then the string data
          * follows.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read_body( BinaryBuffer& buffer ) {
-            uint32_t fSize = buffer.read<uint8_t>();
-            if ( fSize == 255 ) fSize = buffer.read<uint32_t>();
+        void read_body( BinaryStream& stream ) {
+            uint32_t fSize = stream.read<uint8_t>();
+            if ( fSize == 255 ) fSize = stream.read<uint32_t>();
 
             m_offsets->push_back( m_offsets->back() + fSize );
-            for ( int i = 0; i < fSize; i++ ) { m_data->push_back( buffer.read<uint8_t>() ); }
+            for ( int i = 0; i < fSize; i++ ) { m_data->push_back( stream.read<uint8_t>() ); }
         }
 
         /**
-         * @brief Read a string from the buffer. If @ref m_with_header is true, reads a
+         * @brief Read a string from the stream. If @ref m_with_header is true, reads a
          * `fNBytes+fVersion` header before reading the string body.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
+        void read( BinaryStream& stream ) override {
             if ( m_with_header )
             {
-                buffer.read_fNBytes();
-                buffer.read_fVersion();
+                stream.read_fNBytes();
+                stream.read_fVersion();
             }
-            read_body( buffer );
+            read_body( stream );
         }
 
         /**
-         * @brief Read multiple strings from the buffer. If @ref m_with_header is true,
+         * @brief Read multiple strings from the stream. If @ref m_with_header is true,
          * reads a `fNBytes+fVersion` header once before reading multiple strings.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of strings to read. If negative, reads according to the
          * `fNBytes` header.
          * @return Number of strings read.
          */
-        uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many( BinaryStream& stream, const int64_t count ) override {
             if ( count == 0 ) return 0;
             else if ( count < 0 )
             {
                 if ( !m_with_header )
                     throw std::runtime_error( "STLStringReader::read with negative count only "
                                               "supported when with_header is true!" );
-                auto fNBytes  = buffer.read_fNBytes();
-                auto fVersion = buffer.read_fVersion();
+                auto fNBytes  = stream.read_fNBytes();
+                auto fVersion = stream.read_fVersion();
 
-                auto end_pos       = buffer.get_cursor() + fNBytes - 2; // -2 for fVersion
+                auto end_pos       = stream.get_cursor() + fNBytes - 2; // -2 for fVersion
                 uint32_t cur_count = 0;
-                while ( buffer.get_cursor() < end_pos )
+                while ( stream.get_cursor() < end_pos )
                 {
-                    read_body( buffer );
+                    read_body( stream );
                     cur_count++;
                 }
                 return cur_count;
@@ -734,36 +734,36 @@ namespace uproot {
             {
                 if ( m_with_header )
                 {
-                    auto fNBytes  = buffer.read_fNBytes();
-                    auto fVersion = buffer.read_fVersion();
+                    auto fNBytes  = stream.read_fNBytes();
+                    auto fVersion = stream.read_fVersion();
                 }
 
-                for ( auto i = 0; i < count; i++ ) { read_body( buffer ); }
+                for ( auto i = 0; i < count; i++ ) { read_body( stream ); }
                 return count;
             }
         }
 
         /**
-         * @brief Read strings from the buffer until reaching the end position. If @ref
+         * @brief Read strings from the stream until reaching the end position. If @ref
          * m_with_header is true, reads a `fNBytes+fVersion` header once before reading
          * strings.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param end_pos The end position to stop reading.
          * @return Number of strings read.
          */
-        uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) override {
-            if ( buffer.get_cursor() == end_pos ) return 0;
+        uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) override {
+            if ( stream.get_cursor() == end_pos ) return 0;
             if ( m_with_header )
             {
-                buffer.read_fNBytes();
-                buffer.read_fVersion();
+                stream.read_fNBytes();
+                stream.read_fVersion();
             }
 
             int32_t cur_count = 0;
-            while ( buffer.get_cursor() < end_pos )
+            while ( stream.get_cursor() < end_pos )
             {
-                read_body( buffer );
+                read_body( stream );
                 cur_count++;
             }
             return cur_count;
@@ -811,15 +811,15 @@ namespace uproot {
             , m_data( std::make_shared<vector<T>>() ) {}
 
         /**
-         * @brief Read a TArray from the buffer. First reads the size (uint32_t) of the TArray,
+         * @brief Read a TArray from the stream. First reads the size (uint32_t) of the TArray,
          * then reads the elements of the TArray.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
-            auto fSize = buffer.read<uint32_t>();
+        void read( BinaryStream& stream ) override {
+            auto fSize = stream.read<uint32_t>();
             m_offsets->push_back( m_offsets->back() + fSize );
-            for ( auto i = 0; i < fSize; i++ ) { m_data->push_back( buffer.read<T>() ); }
+            for ( auto i = 0; i < fSize; i++ ) { m_data->push_back( stream.read<T>() ); }
         }
 
         /**
@@ -860,30 +860,30 @@ namespace uproot {
             : IReader( name ), m_element_readers( element_readers ) {}
 
         /**
-         * @brief Read all grouped elements from the buffer sequentially.
+         * @brief Read all grouped elements from the stream sequentially.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
+        void read( BinaryStream& stream ) override {
             for ( auto& reader : m_element_readers )
             {
                 debug_printf( "GroupReader %s: reading %s\n", m_name.c_str(),
                               reader->name().c_str() );
-                debug_printf( buffer );
-                reader->read( buffer );
+                debug_printf( stream );
+                reader->read( stream );
             }
         }
 
         /**
-         * @brief Read multiple grouped elements from the buffer sequentially in member-wise
+         * @brief Read multiple grouped elements from the stream sequentially in member-wise
          * mode. This method calls @ref IReader::read_many() of each grouped
          * reader.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of objects to read.
          * @return Number of objects read. Should be equal to @ref count.
          */
-        uint32_t read_many_memberwise( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many_memberwise( BinaryStream& stream, const int64_t count ) override {
             if ( count < 0 )
             {
                 stringstream msg;
@@ -895,8 +895,8 @@ namespace uproot {
             {
                 debug_printf( "GroupReader %s: reading %s\n", m_name.c_str(),
                               reader->name().c_str() );
-                debug_printf( buffer );
-                reader->read_many( buffer, count );
+                debug_printf( stream );
+                reader->read_many( stream, count );
             }
             return count;
         }
@@ -940,44 +940,44 @@ namespace uproot {
             : IReader( name ), m_element_readers( element_readers ) {}
 
         /**
-         * @brief Read the object from the buffer. First reads the `fNBytes+fVersion`
+         * @brief Read the object from the stream. First reads the `fNBytes+fVersion`
          * header, then reads all elements sequentially.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
-            auto fNBytes  = buffer.read_fNBytes();
-            auto fVersion = buffer.read_fVersion();
+        void read( BinaryStream& stream ) override {
+            auto fNBytes  = stream.read_fNBytes();
+            auto fVersion = stream.read_fVersion();
 
-            auto start_pos = buffer.get_cursor();
-            auto end_pos   = buffer.get_cursor() + fNBytes - 2; // -2 for fVersion
+            auto start_pos = stream.get_cursor();
+            auto end_pos   = stream.get_cursor() + fNBytes - 2; // -2 for fVersion
 
             for ( auto& reader : m_element_readers )
             {
                 debug_printf( "AnyClassReader %s: reading %s\n", m_name.c_str(),
                               reader->name().c_str() );
-                debug_printf( buffer );
-                reader->read( buffer );
+                debug_printf( stream );
+                reader->read( stream );
             }
 
-            if ( buffer.get_cursor() != end_pos )
+            if ( stream.get_cursor() != end_pos )
             {
                 stringstream msg;
                 msg << "AnyClassReader: Invalid read length for " << name() << "! Expect "
-                    << end_pos - start_pos << ", got " << buffer.get_cursor() - start_pos;
+                    << end_pos - start_pos << ", got " << stream.get_cursor() - start_pos;
                 throw std::runtime_error( msg.str() );
             }
         }
 
         /**
-         * @brief Read multiple objects from the buffer in member-wise mode. This method
+         * @brief Read multiple objects from the stream in member-wise mode. This method
          * calls @ref IReader::read_many() of each element reader sequentially.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of objects to read.
          * @return Number of objects read. Should be equal to @ref count.
          */
-        uint32_t read_many_memberwise( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many_memberwise( BinaryStream& stream, const int64_t count ) override {
             if ( count < 0 )
             {
                 stringstream msg;
@@ -989,8 +989,8 @@ namespace uproot {
             {
                 debug_printf( "AnyClassReader %s: reading memberwise %s\n", m_name.c_str(),
                               reader->name().c_str() );
-                debug_printf( buffer );
-                reader->read_many( buffer, count );
+                debug_printf( stream );
+                reader->read_many( stream, count );
             }
 
             return count;
@@ -1032,25 +1032,25 @@ namespace uproot {
             , m_element_reader( element_reader )
             , m_object_indexes( std::make_shared<vector<int64_t>>() ) {}
 
-        void check_cursor_position( BinaryBuffer& buffer, const uint32_t expected_nbytes,
+        void check_cursor_position( BinaryStream& stream, const uint32_t expected_nbytes,
                                     const uint8_t* expected_pos ) {
-            if ( buffer.get_cursor() != expected_pos )
+            if ( stream.get_cursor() != expected_pos )
             {
                 stringstream msg;
                 msg << "AnyPointerReader(" << name() << "): Invalid read length! Expect "
                     << expected_nbytes << " bytes, got "
                     << static_cast<int64_t>( expected_nbytes ) -
-                           ( expected_pos - buffer.get_cursor() )
+                           ( expected_pos - stream.get_cursor() )
                     << " bytes.";
                 throw std::runtime_error( msg.str() );
             }
         }
 
-        void read( BinaryBuffer& buffer ) override {
-            auto start_ptr     = buffer.get_cursor();
-            uint32_t start_pos = buffer.get_index();
-            uint32_t ref_begin = start_pos + buffer.get_initial_cursor_offset();
-            auto fNBytes       = buffer.read<uint32_t>();
+        void read( BinaryStream& stream ) override {
+            auto start_ptr     = stream.get_cursor();
+            uint32_t start_pos = stream.get_index();
+            uint32_t ref_begin = start_pos + stream.get_initial_cursor_offset();
+            auto fNBytes       = stream.read<uint32_t>();
 
             int16_t fVersion;
             uint32_t fTag;
@@ -1065,7 +1065,7 @@ namespace uproot {
             else
             {
                 fVersion = 1;
-                fTag     = buffer.read<uint32_t>();
+                fTag     = stream.read<uint32_t>();
                 fNBytes &= ~kByteCountMask;
             }
 
@@ -1075,33 +1075,33 @@ namespace uproot {
             {
                 if ( fTag == 0 )
                 {
-                    check_cursor_position( buffer, fNBytes, end_ptr );
+                    check_cursor_position( stream, fNBytes, end_ptr );
                     m_object_indexes->push_back( -1 ); // use -1 to indicate null pointer
                     return;
                 }
                 else if ( fTag == 1 )
                     throw std::runtime_error( "AnyPointerReader(" + name() +
                                               "): Unsupported fTag value 1" );
-                else if ( buffer.get_refs().find( fTag ) == buffer.get_refs().end() )
+                else if ( stream.get_refs().find( fTag ) == stream.get_refs().end() )
                 {
                     // skip unknown reference
-                    auto nskip = end_ptr - buffer.get_cursor();
-                    buffer.skip( nskip );
-                    check_cursor_position( buffer, fNBytes, end_ptr );
+                    auto nskip = end_ptr - stream.get_cursor();
+                    stream.skip( nskip );
+                    check_cursor_position( stream, fNBytes, end_ptr );
                     return;
                 }
                 else
                 {
-                    auto ref     = buffer.get_refs().at( fTag );
-                    auto ref_idx = std::get<BinaryBuffer::RefObj>( ref ).index;
+                    auto ref     = stream.get_refs().at( fTag );
+                    auto ref_idx = std::get<BinaryStream::RefObj>( ref ).index;
                     m_object_indexes->push_back( ref_idx );
-                    check_cursor_position( buffer, fNBytes, end_ptr );
+                    check_cursor_position( stream, fNBytes, end_ptr );
                     return;
                 }
             }
             else if ( fTag == kNewClassTag )
             {
-                auto class_name = buffer.read_null_terminated_string();
+                auto class_name = stream.read_null_terminated_string();
                 if ( m_class_name.empty() ) m_class_name = class_name;
                 else if ( m_class_name != class_name )
                 {
@@ -1112,27 +1112,27 @@ namespace uproot {
                     throw std::runtime_error( msg.str() );
                 }
 
-                auto& buf_refs = buffer.get_refs();
+                auto& buf_refs = stream.get_refs();
 
                 auto ref_key = fVersion > 0 ? ref_begin + kMapOffset : buf_refs.size() + 1;
-                buf_refs[ref_key] = BinaryBuffer::RefCls{ class_name };
+                buf_refs[ref_key] = BinaryStream::RefCls{ class_name };
 
-                m_element_reader->read( buffer );
+                m_element_reader->read( stream );
                 m_object_indexes->push_back( m_object_counter );
 
                 ref_key = fVersion > 0 ? ref_begin + kMapOffset : buf_refs.size() + 1;
-                buf_refs[ref_key] = BinaryBuffer::RefObj{ m_object_counter };
+                buf_refs[ref_key] = BinaryStream::RefObj{ m_object_counter };
 
                 m_object_counter++;
             }
             else
             {
-                auto& buf_refs   = buffer.get_refs();
+                auto& buf_refs   = stream.get_refs();
                 auto cls_ref_key = fTag & ( ~kClassMask );
                 if ( buf_refs.find( cls_ref_key ) != buf_refs.end() )
                 {
                     auto class_name =
-                        std::get<BinaryBuffer::RefCls>( buf_refs.at( cls_ref_key ) ).name;
+                        std::get<BinaryStream::RefCls>( buf_refs.at( cls_ref_key ) ).name;
                     if ( class_name != m_class_name )
                     {
                         stringstream msg;
@@ -1143,16 +1143,16 @@ namespace uproot {
                     }
                 }
 
-                m_element_reader->read( buffer );
+                m_element_reader->read( stream );
                 m_object_indexes->push_back( m_object_counter );
 
                 auto obj_ref_key = fVersion > 0 ? ref_begin + kMapOffset : buf_refs.size() + 1;
-                buf_refs[obj_ref_key] = BinaryBuffer::RefObj{ m_object_counter };
+                buf_refs[obj_ref_key] = BinaryStream::RefObj{ m_object_counter };
 
                 m_object_counter++;
             }
 
-            check_cursor_position( buffer, fNBytes, end_ptr );
+            check_cursor_position( stream, fNBytes, end_ptr );
         }
 
         py::object data() const override {
@@ -1186,28 +1186,28 @@ namespace uproot {
             : IReader( name ), m_element_reader( element_reader ) {}
 
         /**
-         * @brief Read the object header from the buffer, then delegate to @ref
+         * @brief Read the object header from the stream, then delegate to @ref
          * m_element_reader to read the object content.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
-            auto nbytes    = buffer.read_fNBytes();
-            auto start_pos = buffer.get_cursor();
-            auto end_pos   = buffer.get_cursor() + nbytes;
+        void read( BinaryStream& stream ) override {
+            auto nbytes    = stream.read_fNBytes();
+            auto start_pos = stream.get_cursor();
+            auto end_pos   = stream.get_cursor() + nbytes;
 
-            auto fTag = buffer.read<int32_t>();
+            auto fTag = stream.read<int32_t>();
             if ( fTag == kNewClassTag )
-            { auto fTypename = buffer.read_null_terminated_string(); }
+            { auto fTypename = stream.read_null_terminated_string(); }
 
-            m_element_reader->read( buffer );
+            m_element_reader->read( stream );
 
-            if ( buffer.get_cursor() != end_pos )
+            if ( stream.get_cursor() != end_pos )
             {
                 stringstream msg;
                 msg << "ObjectHeaderReader: Invalid read length for "
                     << m_element_reader->name() << "! Expect " << end_pos - start_pos
-                    << ", got " << buffer.get_cursor() - start_pos;
+                    << ", got " << stream.get_cursor() - start_pos;
                 throw std::runtime_error( msg.str() );
             }
         }
@@ -1253,31 +1253,31 @@ namespace uproot {
             , m_element_reader( element_reader ) {}
 
         /**
-         * @brief Read the array from the buffer. If @ref m_flat_size is positive, calls @ref
+         * @brief Read the array from the stream. If @ref m_flat_size is positive, calls @ref
          * IReader::read_many() function of @ref m_element_reader. Otherwise, reads
-         * until the end of the current entry in the buffer.
+         * until the end of the current entry in the stream.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          */
-        void read( BinaryBuffer& buffer ) override {
+        void read( BinaryStream& stream ) override {
             debug_printf( "CStyleArrayReader(%s) with flat_size %ld\n", m_name.c_str(),
                           m_flat_size );
-            debug_printf( buffer );
+            debug_printf( stream );
 
-            if ( m_flat_size >= 0 ) { m_element_reader->read_many( buffer, m_flat_size ); }
+            if ( m_flat_size >= 0 ) { m_element_reader->read_many( stream, m_flat_size ); }
             else
             {
                 // get end-position
-                auto n_entries     = buffer.entries();
-                auto start_pos     = buffer.get_data();
-                auto entry_offsets = buffer.get_offsets();
-                auto cursor_pos    = buffer.get_cursor();
+                auto n_entries     = stream.entries();
+                auto start_pos     = stream.get_data();
+                auto entry_offsets = stream.get_offsets();
+                auto cursor_pos    = stream.get_cursor();
                 auto entry_end = std::find_if( entry_offsets, entry_offsets + n_entries + 1,
                                                [start_pos, cursor_pos]( uint32_t offset ) {
                                                    return start_pos + offset > cursor_pos;
                                                } );
                 auto end_pos   = start_pos + *entry_end;
-                uint32_t count = m_element_reader->read_until( buffer, end_pos );
+                uint32_t count = m_element_reader->read_until( stream, end_pos );
                 m_offsets->push_back( m_offsets->back() + count );
                 debug_printf( "CStyleArrayReader(%s) read %d elements\n", m_name.c_str(),
                               count );
@@ -1285,14 +1285,14 @@ namespace uproot {
         }
 
         /**
-         * @brief Read multiple arrays from the buffer. Only supported when @ref m_flat_size
+         * @brief Read multiple arrays from the stream. Only supported when @ref m_flat_size
          * is positive.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param count Number of arrays to read.
          * @return Number of arrays read.
          */
-        uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) override {
+        uint32_t read_many( BinaryStream& stream, const int64_t count ) override {
             if ( m_flat_size < 0 )
             {
                 stringstream msg;
@@ -1307,21 +1307,21 @@ namespace uproot {
             }
 
             for ( auto i = 0; i < count; i++ )
-                m_element_reader->read_many( buffer, m_flat_size );
+                m_element_reader->read_many( stream, m_flat_size );
 
             return count;
         }
 
         /**
-         * @brief Read arrays from the buffer until reaching the end position. Not supported.
+         * @brief Read arrays from the stream until reaching the end position. Not supported.
          *
-         * @param buffer The binary buffer to read from.
+         * @param stream The binary stream to read from.
          * @param end_pos The end position to stop reading.
          * @return Number of arrays read.
          *
          * @exception std::runtime_error Always thrown since this method is not supported.
          */
-        uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) override {
+        uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) override {
             throw std::runtime_error( "CStyleArrayReader::read with end_pos not supported!" );
         }
 
@@ -1364,7 +1364,7 @@ namespace uproot {
         /**
          * @brief Do nothing.
          */
-        void read( BinaryBuffer& ) override {}
+        void read( BinaryStream& ) override {}
 
         /**
          * @brief Return None.
@@ -1379,7 +1379,7 @@ namespace uproot {
     */
 
     /**
-     * @brief Read data from a binary buffer using the provided reader.
+     * @brief Read data from a binary stream using the provided reader.
      *
      * @param data Binary data as a numpy array of uint8_t
      * @param offsets Offsets for each entry as a numpy array of uint32_t
@@ -1388,20 +1388,20 @@ namespace uproot {
      */
     py::object py_read_data( py::array_t<uint8_t> data, py::array_t<uint32_t> offsets,
                              uint32_t cursor_offset, SharedReader reader ) {
-        BinaryBuffer buffer( data, offsets, cursor_offset );
-        for ( auto i_evt = 0; i_evt < buffer.entries(); i_evt++ )
+        BinaryStream stream( data, offsets, cursor_offset );
+        for ( auto i_evt = 0; i_evt < stream.entries(); i_evt++ )
         {
-            auto start_pos = buffer.get_cursor();
-            reader->read( buffer );
-            auto end_pos = buffer.get_cursor();
+            auto start_pos = stream.get_cursor();
+            reader->read( stream );
+            auto end_pos = stream.get_cursor();
 
             if ( end_pos - start_pos !=
-                 buffer.get_offsets()[i_evt + 1] - buffer.get_offsets()[i_evt] )
+                 stream.get_offsets()[i_evt + 1] - stream.get_offsets()[i_evt] )
             {
                 stringstream msg;
                 msg << "py_read_data: Invalid read length for " << reader->name()
                     << " at event " << i_evt << "! Expect "
-                    << buffer.get_offsets()[i_evt + 1] - buffer.get_offsets()[i_evt]
+                    << stream.get_offsets()[i_evt + 1] - stream.get_offsets()[i_evt]
                     << ", got " << end_pos - start_pos;
                 throw std::runtime_error( msg.str() );
             }
@@ -1412,7 +1412,7 @@ namespace uproot {
     PYBIND11_MODULE( cpp, m ) {
         m.doc() = "C++ module for uproot-custom";
 
-        m.def( "read_data", &py_read_data, "Read data from a binary buffer", py::arg( "data" ),
+        m.def( "read_data", &py_read_data, "Read data from a binary stream", py::arg( "data" ),
                py::arg( "offsets" ), py::arg( "cursor_offset" ), py::arg( "reader" ) );
 
         py::class_<IReader, SharedReader>( m, "IReader" )

--- a/docs/example/override-streamer.md
+++ b/docs/example/override-streamer.md
@@ -126,20 +126,20 @@ class OverrideStreamerReader(IReader):
         self.m_ints = array("i")       # int32
         self.m_doubles = array("d")    # float64
 
-    def read(self, buffer):
+    def read(self, stream):
         # Skip TObject header
-        buffer.skip_TObject()
+        stream.skip_TObject()
 
         # Read integer value
-        self.m_ints.append(buffer.read_int32())
+        self.m_ints.append(stream.read_int32())
 
         # Read a custom added mask value
-        mask = buffer.read_uint32()
+        mask = stream.read_uint32()
         if mask != 0x12345678:
             raise RuntimeError(f"Error: Unexpected mask value: {mask:#x}")
 
         # Read double value
-        self.m_doubles.append(buffer.read_double())
+        self.m_doubles.append(stream.read_double())
 
     def data(self):
         int_array = np.asarray(self.m_ints)
@@ -302,7 +302,7 @@ order, and `data()` returning the same structure.
 
 ```{seealso}
 See [](../../tutorial/customize-factory-reader/port-to-cpp.md) for the full
-C++ reader API reference (IReader, BinaryBuffer, pybind11 bindings).
+C++ reader API reference (IReader, BinaryStream, pybind11 bindings).
 ```
 
 ```{code-block} cpp
@@ -326,15 +326,15 @@ class OverrideStreamerReader : public IReader {
         , m_data_ints( std::make_shared<std::vector<int>>() )
         , m_data_doubles( std::make_shared<std::vector<double>>() ) {}
 
-    void read( BinaryBuffer& buffer ) {
+    void read( BinaryStream& stream ) {
         // Skip TObject header
-        buffer.skip_TObject();
+        stream.skip_TObject();
 
         // Read integer value
-        m_data_ints->push_back( buffer.read<int>() );
+        m_data_ints->push_back( stream.read<int>() );
 
         // Read a custom added mask value
-        auto mask = buffer.read<uint32_t>();
+        auto mask = stream.read<uint32_t>();
         if ( mask != 0x12345678 )
         {
             throw std::runtime_error( "Error: Unexpected mask value: " +
@@ -342,7 +342,7 @@ class OverrideStreamerReader : public IReader {
         }
 
         // Read double value
-        m_data_doubles->push_back( buffer.read<double>() );
+        m_data_doubles->push_back( stream.read<double>() );
     }
 
     py::object data() const {

--- a/docs/example/read-tobjarray.md
+++ b/docs/example/read-tobjarray.md
@@ -218,7 +218,7 @@ Our `TObjArrayReader` in Python can be implemented as follows:
 from array import array
 import numpy as np
 
-from uproot_custom.readers.python import IReader, BinaryBuffer
+from uproot_custom.readers.python import IReader, BinaryStream
 
 
 class TObjArrayReader(IReader):
@@ -227,20 +227,20 @@ class TObjArrayReader(IReader):
         self.element_reader = element_reader
         self.offsets = array("q", [0])
 
-    def read(self, buffer):
+    def read(self, stream):
         # Read TObjArray header
-        buffer.skip_fNBytes()
-        buffer.skip_fVersion()
-        buffer.skip_TObject()
-        buffer.read_TString()  # fName
-        fSize = buffer.read_uint32()
-        buffer.skip(4)  # fLowerBound
+        stream.skip_fNBytes()
+        stream.skip_fVersion()
+        stream.skip_TObject()
+        stream.read_TString()  # fName
+        fSize = stream.read_uint32()
+        stream.skip(4)  # fLowerBound
 
         # Record the new offset
         self.offsets.append(self.offsets[-1] + fSize)
 
         # Read the elements using the element reader
-        self.element_reader.read_many(buffer, fSize)
+        self.element_reader.read_many(stream, fSize)
 
     def data(self):
         offsets_array = np.asarray(self.offsets)
@@ -434,7 +434,7 @@ the same structure.
 
 ```{seealso}
 See [](../../tutorial/customize-factory-reader/port-to-cpp.md) for the full
-C++ reader API reference (IReader, BinaryBuffer, pybind11 bindings).
+C++ reader API reference (IReader, BinaryStream, pybind11 bindings).
 ```
 
 ```{code-block} cpp
@@ -452,16 +452,16 @@ class TObjArrayReader : public IReader {
         , m_element_reader( element_reader )
         , m_offsets( std::make_shared<std::vector<int64_t>>( 1, 0 ) ) {}
 
-    void read( BinaryBuffer& buffer ) override final {
-        buffer.skip_fNBytes();
-        buffer.skip_fVersion();
-        buffer.skip_TObject();
-        buffer.read_TString(); // fName
-        auto fSize = buffer.read<uint32_t>();
-        buffer.skip( 4 ); // fLowerBound
+    void read( BinaryStream& stream ) override final {
+        stream.skip_fNBytes();
+        stream.skip_fVersion();
+        stream.skip_TObject();
+        stream.read_TString(); // fName
+        auto fSize = stream.read<uint32_t>();
+        stream.skip( 4 ); // fLowerBound
 
         m_offsets->push_back( m_offsets->back() + fSize );
-        m_element_reader->read_many( buffer, fSize );
+        m_element_reader->read_many( stream, fSize );
     }
 
     py::object data() const override final {

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ flowchart TD
     raw_data --> build_ak
 ```
 
-- `Reader` is a class that implements the logic to read data from binary buffers. It can be written in **Python** (for development and debugging) or **C++** (for production performance).
+- `Reader` is a class that implements the logic to read data from binary streams. It can be written in **Python** (for development and debugging) or **C++** (for production performance).
 - `Factory` is a Python class that creates, combines `Reader`s, and post-processes the data read by `Reader`s.
 
 This mechanism is implemented as `AsCustom` interpretation. This makes uproot-custom well compatible with Uproot.

--- a/docs/reference/reader-backends.md
+++ b/docs/reference/reader-backends.md
@@ -42,7 +42,7 @@ default C++ backend for production.
 - Use **Python** when:
   - You are developing and prototyping new readers.
   - You need to debug reader behavior interactively (e.g., step through Python
-    readers or print buffer state).
+    readers or print stream state).
   - You are on a platform without a C++17 toolchain or cannot build the native
     extension.
 - Prefer **C++** for any real analysis, performance-sensitive jobs, or large

--- a/docs/tutorial/customize-factory-reader.md
+++ b/docs/tutorial/customize-factory-reader.md
@@ -16,7 +16,7 @@ the default C++ backend.
 
 By the end of this tutorial you will have:
 
-- A **Python reader** that decodes binary data from the ROOT byte buffer.
+- A **Python reader** that decodes binary data from the ROOT byte stream.
 - A **Python factory** that creates the reader, converts raw arrays into
   `awkward` arrays, and describes the data layout for `dask`.
 - A **registration** step so Uproot picks up your custom code automatically.

--- a/docs/tutorial/customize-factory-reader/investigate-data.md
+++ b/docs/tutorial/customize-factory-reader/investigate-data.md
@@ -352,7 +352,7 @@ This is the typical scenario where uproot-custom is needed.
 (obtain-binary-data)=
 ### Obtaining raw binary data
 
-Use `AsBinary` to pull the uninterpreted byte buffer of a branch:
+Use `AsBinary` to pull the uninterpreted byte stream of a branch:
 
 ```python
 from uproot.interpretations.custom import AsBinary
@@ -414,15 +414,15 @@ class: tip, dropdown
 The built-in `TObjectReader::read` method:
 
 ```cpp
-void read( BinaryBuffer& buffer ) override {
-    buffer.skip_fVersion();
-    auto fUniqueID = buffer.read<int32_t>();
-    auto fBits     = buffer.read<uint32_t>();
+void read( BinaryStream& stream ) override {
+    stream.skip_fVersion();
+    auto fUniqueID = stream.read<int32_t>();
+    auto fBits     = stream.read<uint32_t>();
 
-    if ( fBits & ( BinaryBuffer::kIsReferenced ) )
+    if ( fBits & ( BinaryStream::kIsReferenced ) )
     {
-        if ( m_keep_data ) m_pidf->push_back( buffer.read<uint16_t>() );
-        else buffer.skip( 2 );
+        if ( m_keep_data ) m_pidf->push_back( stream.read<uint16_t>() );
+        else stream.skip( 2 );
     }
 
     if ( m_keep_data )

--- a/docs/tutorial/customize-factory-reader/pipeline.md
+++ b/docs/tutorial/customize-factory-reader/pipeline.md
@@ -11,7 +11,7 @@ At a high level the pipeline has five stages:
    hierarchy.
 2. **Build readers** — each factory creates a corresponding `Reader` (Python
    or C++).
-3. **Read binary data** — the composed reader graph walks the byte buffer.
+3. **Read binary data** — the composed reader graph walks the byte stream.
 4. **Return raw data** — leaf readers return `numpy` arrays; parent readers
    assemble them into nested tuples / lists.
 5. **Build awkward arrays** — factories convert the raw arrays into
@@ -148,24 +148,24 @@ class AnyClassFactory(GroupFactory):
 
 The top-level reader drives sub-readers recursively. For instance,
 `AnyClassReader` reads its `fNBytes` + `fVersion` header, then asks each
-sub-reader to consume its portion of the buffer:
+sub-reader to consume its portion of the stream:
 
 ```{code-block} python
 ---
 caption: "`AnyClassReader.read` method (Python)"
 emphasize-lines: 7
 ---
-def read(self, buffer):
-    fNBytes = buffer.read_fNBytes()
-    start_pos = buffer.cursor
+def read(self, stream):
+    fNBytes = stream.read_fNBytes()
+    start_pos = stream.cursor
     end_pos = start_pos + fNBytes
 
-    buffer.skip_fVersion()
+    stream.skip_fVersion()
 
     for reader in self.element_readers:
-        reader.read(buffer)
+        reader.read(stream)
 
-    assert buffer.cursor == end_pos, (
+    assert stream.cursor == end_pos, (
         f"AnyClassReader({self.name}): Invalid read length!"
     )
 ```
@@ -361,7 +361,7 @@ class OverrideStreamerFactory(Factory):
 ### Stage 2 — Reader
 
 The reader implements the binary decoding logic. It reads every entry from
-the byte buffer and accumulates values in Python `array` objects, then
+the byte stream and accumulates values in Python `array` objects, then
 returns them as `numpy` arrays.
 
 ```{code-block} python
@@ -380,16 +380,16 @@ class OverrideStreamerReader(IReader):
         self.m_ints = array("i")       # int32
         self.m_doubles = array("d")    # float64
 
-    def read(self, buffer):
+    def read(self, stream):
         # Stage 3 — read binary data
-        buffer.skip_TObject()                        # skip base class
-        self.m_ints.append(buffer.read_int32())      # m_int
+        stream.skip_TObject()                        # skip base class
+        self.m_ints.append(stream.read_int32())      # m_int
 
-        mask = buffer.read_uint32()                  # custom mask
+        mask = stream.read_uint32()                  # custom mask
         if mask != 0x12345678:
             raise RuntimeError(f"Unexpected mask: {mask:#x}")
 
-        self.m_doubles.append(buffer.read_double())  # m_double
+        self.m_doubles.append(stream.read_double())  # m_double
 
     def data(self):
         # Stage 4 — return raw numpy arrays

--- a/docs/tutorial/customize-factory-reader/port-to-cpp.md
+++ b/docs/tutorial/customize-factory-reader/port-to-cpp.md
@@ -21,16 +21,16 @@ methods:
 
 | Method | Purpose |
 | ------ | ------- |
-| `read(BinaryBuffer&)` | Consume bytes from the buffer for one entry. |
+| `read(BinaryStream&)` | Consume bytes from the stream for one entry. |
 | `data() → py::object` | Return all accumulated data as `numpy` arrays (or nested containers of them). |
 
 The same optional methods are available as in Python:
 
 | Method | When it is called |
 | ------ | ----------------- |
-| `read_many(buffer, count)` | Reading a fixed number of elements. |
-| `read_until(buffer, end_pos)` | Reading elements until a byte position. |
-| `read_many_memberwise(buffer, count)` | Member-wise reading for STL containers. |
+| `read_many(stream, count)` | Reading a fixed number of elements. |
+| `read_until(stream, end_pos)` | Reading elements until a byte position. |
+| `read_many_memberwise(stream, count)` | Member-wise reading for STL containers. |
 
 ```{code-block} cpp
 ---
@@ -48,50 +48,50 @@ class IReader {
 
     virtual const std::string name() const { return m_name; }
 
-    virtual void read( BinaryBuffer& buffer ) = 0;
+    virtual void read( BinaryStream& stream ) = 0;
     virtual py::object data() const           = 0;
 
-    virtual uint32_t read_many( BinaryBuffer& buffer, const int64_t count ) {
-        for ( int32_t i = 0; i < count; i++ ) { read( buffer ); }
+    virtual uint32_t read_many( BinaryStream& stream, const int64_t count ) {
+        for ( int32_t i = 0; i < count; i++ ) { read( stream ); }
         return count;
     }
 
-    virtual uint32_t read_until( BinaryBuffer& buffer, const uint8_t* end_pos ) {
+    virtual uint32_t read_until( BinaryStream& stream, const uint8_t* end_pos ) {
         uint32_t cur_count = 0;
-        while ( buffer.get_cursor() < end_pos )
+        while ( stream.get_cursor() < end_pos )
         {
-            read( buffer );
+            read( stream );
             cur_count++;
         }
         return cur_count;
     }
 
-    virtual uint32_t read_many_memberwise( BinaryBuffer& buffer, const int64_t count ) {
+    virtual uint32_t read_many_memberwise( BinaryStream& stream, const int64_t count ) {
         if ( count < 0 )
         {
             std::stringstream msg;
             msg << name() << "::read_many_memberwise with negative count: " << count;
             throw std::runtime_error( msg.str() );
         }
-        return read_many( buffer, count );
+        return read_many( stream, count );
     }
 };
 ```
 
 ---
 
-## C++ `BinaryBuffer`
+## C++ `BinaryStream`
 
-The C++ `BinaryBuffer` wraps a `uint8_t*` buffer with the same convenience
+The C++ `BinaryStream` wraps a `uint8_t*` stream with the same convenience
 methods as the Python version:
 
 **Reading**
-- `const T read<T>()`: Read a value of type `T` from the buffer, and advance the cursor.
+- `const T read<T>()`: Read a value of type `T` from the stream, and advance the cursor.
 - `const int16_t read_fVersion()`: Equivalent to `read<int16_t>()`.
-- `const uint32_t read_fNBytes()`: Read `fNBytes` from the buffer, check the mask, and return the actual number of bytes.
-- `const std::string read_null_terminated_string()`: Read a null-terminated string from the buffer.
-- `const std::string read_obj_header()`: Read the object header from the buffer, return the object's name if present.
-- `const std::string read_TString()`: Read a `TString` from the buffer.
+- `const uint32_t read_fNBytes()`: Read `fNBytes` from the stream, check the mask, and return the actual number of bytes.
+- `const std::string read_null_terminated_string()`: Read a null-terminated string from the stream.
+- `const std::string read_obj_header()`: Read the object header from the stream, return the object's name if present.
+- `const std::string read_TString()`: Read a `TString` from the stream.
 
 **Skipping**
 - `void skip(const size_t nbytes)`: Skip `nbytes` bytes.
@@ -102,10 +102,10 @@ methods as the Python version:
 - `void skip_TObject()`: Skip a `TObject`.
 
 **Miscellaneous**
-- `const uint8_t* get_data() const`: Get the start of the data buffer.
+- `const uint8_t* get_data() const`: Get the start of the data stream.
 - `const uint8_t* get_cursor() const`: Get the current cursor position.
-- `const uint32_t* get_offsets() const`: Get the entry offsets of the data buffer.
-- `const uint64_t* entries() const`: Get the number of entries of the data buffer.
+- `const uint32_t* get_offsets() const`: Get the entry offsets of the data stream.
+- `const uint64_t* entries() const`: Get the number of entries of the data stream.
 - `void debug_print( const size_t n = 100 ) const`: Print the next `n` bytes from the current cursor for debugging.
 
 ---
@@ -166,8 +166,8 @@ emitted when the `UPROOT_DEBUG` macro is defined at compile time **or** the
 // Will print "The reader name is Bob"
 debug_print("The reader name is %s", "Bob");
 
-// Call buffer.debug_print(50), print next 50 bytes from current cursor
-debug_print( buffer, 50 )
+// Call stream.debug_print(50), print next 50 bytes from current cursor
+debug_print( stream, 50 )
 ```
 
 ---
@@ -207,15 +207,15 @@ class OverrideStreamerReader(IReader):
         self.m_ints = array("i")       # int32
         self.m_doubles = array("d")    # float64
 
-    def read(self, buffer):
-        buffer.skip_TObject()                        # skip base class
-        self.m_ints.append(buffer.read_int32())      # m_int
+    def read(self, stream):
+        stream.skip_TObject()                        # skip base class
+        self.m_ints.append(stream.read_int32())      # m_int
 
-        mask = buffer.read_uint32()                  # custom mask
+        mask = stream.read_uint32()                  # custom mask
         if mask != 0x12345678:
             raise RuntimeError(f"Unexpected mask: {mask:#x}")
 
-        self.m_doubles.append(buffer.read_double())  # m_double
+        self.m_doubles.append(stream.read_double())  # m_double
 
     def data(self):
         return np.asarray(self.m_ints), np.asarray(self.m_doubles)
@@ -243,16 +243,16 @@ class OverrideStreamerReader : public IReader {
         , m_data_ints( std::make_shared<std::vector<int>>() )
         , m_data_doubles( std::make_shared<std::vector<double>>() ) {}
 
-    void read( BinaryBuffer& buffer ) {
-        buffer.skip_TObject();                          // skip base class
-        m_data_ints->push_back( buffer.read<int>() );   // m_int
+    void read( BinaryStream& stream ) {
+        stream.skip_TObject();                          // skip base class
+        m_data_ints->push_back( stream.read<int>() );   // m_int
 
-        auto mask = buffer.read<uint32_t>();             // custom mask
+        auto mask = stream.read<uint32_t>();             // custom mask
         if ( mask != 0x12345678 )
             throw std::runtime_error( "Unexpected mask: " +
                                       std::to_string( mask ) );
 
-        m_data_doubles->push_back( buffer.read<double>() ); // m_double
+        m_data_doubles->push_back( stream.read<double>() ); // m_double
     }
 
     py::object data() const {
@@ -312,10 +312,10 @@ class TArrayReader : public IReader {
         , m_offsets( std::make_shared<std::vector<int64_t>>( 1, 0 ) )
         , m_data( std::make_shared<std::vector<T>>() ) {}
 
-    void read( BinaryBuffer& buffer ) override {
-        auto fSize = buffer.read<uint32_t>();
+    void read( BinaryStream& stream ) override {
+        auto fSize = stream.read<uint32_t>();
         m_offsets->push_back( m_offsets->back() + fSize );
-        for ( auto i = 0; i < fSize; i++ ) { m_data->push_back( buffer.read<T>() ); }
+        for ( auto i = 0; i < fSize; i++ ) { m_data->push_back( stream.read<T>() ); }
     }
 
     py::object data() const override {

--- a/docs/tutorial/customize-factory-reader/reader-and-factory.md
+++ b/docs/tutorial/customize-factory-reader/reader-and-factory.md
@@ -2,7 +2,7 @@
 
 Uproot-custom splits the work between two layers:
 
-- **Reader** — reads binary data from the ROOT byte buffer. It can be written
+- **Reader** — reads binary data from the ROOT byte stream. It can be written
   in **Python** (for rapid development and debugging) or **C++** (for
   production performance).
 - **Factory** (Python) — orchestrates readers, and converts their output into
@@ -22,7 +22,7 @@ and implement two methods:
 
 | Method | Purpose |
 | ------ | ------- |
-| `read(buffer)` | Consume bytes from the buffer for one entry. |
+| `read(stream)` | Consume bytes from the stream for one entry. |
 | `data()` | Return all accumulated data as `numpy` arrays (or nested containers of them). |
 
 Three additional methods handle special reading patterns (override only when
@@ -30,9 +30,9 @@ needed):
 
 | Method | When it is called |
 | ------ | ----------------- |
-| `read_many(buffer, count)` | Reading a fixed number of elements (e.g. c-style arrays). Override when multiple elements share a single header. |
-| `read_until(buffer, end_pos)` | Reading elements until a byte position is reached. |
-| `read_many_memberwise(buffer, count)` | Member-wise reading: all first members, then all second members, etc. Used by some STL containers. |
+| `read_many(stream, count)` | Reading a fixed number of elements (e.g. c-style arrays). Override when multiple elements share a single header. |
+| `read_until(stream, end_pos)` | Reading elements until a byte position is reached. |
+| `read_many_memberwise(stream, count)` | Member-wise reading: all first members, then all second members, etc. Used by some STL containers. |
 
 ```{code-block} python
 ---
@@ -44,25 +44,25 @@ class IReader:
     def __init__(self, name: str):
         self.name = name
 
-    def read(self, buffer: BinaryBuffer) -> None:
+    def read(self, stream: BinaryStream) -> None:
         raise NotImplementedError
 
     def data(self):
         raise NotImplementedError
 
-    def read_many(self, buffer: BinaryBuffer, count: int) -> int:
+    def read_many(self, stream: BinaryStream, count: int) -> int:
         for _ in range(count):
-            self.read(buffer)
+            self.read(stream)
         return count
 
-    def read_until(self, buffer: BinaryBuffer, end_pos: int) -> int:
+    def read_until(self, stream: BinaryStream, end_pos: int) -> int:
         count = 0
-        while buffer.cursor < end_pos:
-            self.read(buffer)
+        while stream.cursor < end_pos:
+            self.read(stream)
             count += 1
         return count
 
-    def read_many_memberwise(self, buffer: BinaryBuffer, count: int) -> int:
+    def read_many_memberwise(self, stream: BinaryStream, count: int) -> int:
         raise NotImplementedError
 ```
 
@@ -70,9 +70,9 @@ class IReader:
 Every reader requires a `name: str` for debug output.
 ```
 
-### `BinaryBuffer`
+### `BinaryStream`
 
-`BinaryBuffer` wraps a byte buffer and provides convenience methods for
+`BinaryStream` wraps a byte stream and provides convenience methods for
 reading ROOT binary data.
 
 **Reading**
@@ -81,10 +81,10 @@ reading ROOT binary data.
 - `read_float() → float`, `read_double() → float`: Read floating-point values.
 - `read_bool() → bool`: Read a boolean value.
 - `read_fVersion() → int`: Read `fVersion` (signed 16-bit).
-- `read_fNBytes() → int`: Read `fNBytes` from the buffer, check the mask, and return the actual number of bytes.
-- `read_null_terminated_string() → str`: Read a null-terminated string from the buffer.
+- `read_fNBytes() → int`: Read `fNBytes` from the stream, check the mask, and return the actual number of bytes.
+- `read_null_terminated_string() → str`: Read a null-terminated string from the stream.
 - `read_obj_header() → str`: Read the object header, return the object's name if present.
-- `read_TString() → str`: Read a `TString` from the buffer.
+- `read_TString() → str`: Read a `TString` from the stream.
 
 **Skipping**
 - `skip(n)`: Skip `n` bytes.
@@ -95,9 +95,9 @@ reading ROOT binary data.
 - `skip_TObject()`: Skip a `TObject`.
 
 **Miscellaneous**
-- `cursor`: Current cursor position (byte index into the buffer).
-- `entries`: Number of entries in the data buffer.
-- `offsets`: Entry offsets of the data buffer.
+- `cursor`: Current cursor position (byte index into the stream).
+- `entries`: Number of entries in the data stream.
+- `offsets`: Entry offsets of the data stream.
 
 ### Accepting sub-readers
 
@@ -118,11 +118,11 @@ os.environ["UPROOT_DEBUG"] = "1"
 # Now debug_print(...) calls will produce output
 ```
 
-You can also print the current buffer state:
+You can also print the current stream state:
 
 ```python
-def read(self, buffer):
-    print(buffer)   # shows the next N bytes from the current cursor
+def read(self, stream):
+    print(stream)   # shows the next N bytes from the current cursor
     ...
 ```
 
@@ -294,7 +294,7 @@ caption: "`TArrayReader` (Python)"
 from array import array
 import numpy as np
 
-from uproot_custom.readers.python import IReader, BinaryBuffer, DTYPE_TO_READER, DTYPE_TO_TYPECODE
+from uproot_custom.readers.python import IReader, BinaryStream, DTYPE_TO_READER, DTYPE_TO_TYPECODE
 
 
 class TArrayReader(IReader):
@@ -306,11 +306,11 @@ class TArrayReader(IReader):
         self.offsets = array("q", [0])
         self.buffer_reader = DTYPE_TO_READER[dtype]
 
-    def read(self, buffer):
-        fSize = buffer.read_uint32()
+    def read(self, stream):
+        fSize = stream.read_uint32()
         self.offsets.append(self.offsets[-1] + fSize)
         for _ in range(fSize):
-            self._data.append(self.buffer_reader(buffer))
+            self._data.append(self.buffer_reader(stream))
 
     def data(self):
         offsets_array = np.frombuffer(self.offsets.tobytes(), dtype="int64")
@@ -403,7 +403,7 @@ class TArrayFactory(Factory):
 ```{seealso}
 Once your Python reader is working correctly, you can port the logic to C++
 for production performance. See [](port-to-cpp.md) for the C++ `IReader` API,
-`BinaryBuffer` reference, pybind11 bindings, and a worked C++ version of
+`BinaryStream` reference, pybind11 bindings, and a worked C++ version of
 `TArrayReader`.
 ```
 

--- a/uproot_custom/readers/python.py
+++ b/uproot_custom/readers/python.py
@@ -34,7 +34,7 @@ class _Reference:
     object_index: Optional[int] = None
 
 
-class BinaryBuffer:
+class BinaryStream:
     def __init__(
         self,
         data: NDArray[np.uint8],
@@ -206,29 +206,29 @@ class BinaryBuffer:
             replace_whitespace=False,
         )
 
-        return "BinaryBuffer:\n" + wrapper.fill(res) + "]"
+        return "BinaryStream:\n" + wrapper.fill(res) + "]"
 
 
 class IReader:
     def __init__(self, name: str):
         self.name = name
 
-    def read(self, buffer: BinaryBuffer) -> None:
+    def read(self, stream: BinaryStream) -> None:
         raise NotImplementedError
 
-    def read_many(self, buffer: BinaryBuffer, count: int) -> int:
+    def read_many(self, stream: BinaryStream, count: int) -> int:
         for _ in range(count):
-            self.read(buffer)
+            self.read(stream)
         return count
 
-    def read_until(self, buffer: BinaryBuffer, end_pos: int) -> int:
+    def read_until(self, stream: BinaryStream, end_pos: int) -> int:
         count = 0
-        while buffer.cursor < end_pos:
-            self.read(buffer)
+        while stream.cursor < end_pos:
+            self.read(stream)
             count += 1
         return count
 
-    def read_many_memberwise(self, buffer: BinaryBuffer, count: int) -> int:
+    def read_many_memberwise(self, stream: BinaryStream, count: int) -> int:
         raise NotImplementedError(
             f"{self.__class__.__name__}({self.name}).read_many_memberwise is not implemented"
         )
@@ -251,18 +251,18 @@ DTYPE_TO_TYPECODE = {
     "bool": "B",
 }
 
-DTYPE_TO_READER: dict[str, Callable[[BinaryBuffer], int]] = {
-    "uint8": BinaryBuffer.read_uint8,
-    "uint16": BinaryBuffer.read_uint16,
-    "uint32": BinaryBuffer.read_uint32,
-    "uint64": BinaryBuffer.read_uint64,
-    "int8": BinaryBuffer.read_int8,
-    "int16": BinaryBuffer.read_int16,
-    "int32": BinaryBuffer.read_int32,
-    "int64": BinaryBuffer.read_int64,
-    "float32": BinaryBuffer.read_float,
-    "float64": BinaryBuffer.read_double,
-    "bool": BinaryBuffer.read_bool,
+DTYPE_TO_READER: dict[str, Callable[[BinaryStream], int]] = {
+    "uint8": BinaryStream.read_uint8,
+    "uint16": BinaryStream.read_uint16,
+    "uint32": BinaryStream.read_uint32,
+    "uint64": BinaryStream.read_uint64,
+    "int8": BinaryStream.read_int8,
+    "int16": BinaryStream.read_int16,
+    "int32": BinaryStream.read_int32,
+    "int64": BinaryStream.read_int64,
+    "float32": BinaryStream.read_float,
+    "float64": BinaryStream.read_double,
+    "bool": BinaryStream.read_bool,
 }
 
 
@@ -290,8 +290,8 @@ class PrimitiveReader(IReader):
         self._data = array(self.typecode)
         self.buffer_reader = DTYPE_TO_READER[dtype]
 
-    def read(self, buffer):
-        self._data.append(self.buffer_reader(buffer))
+    def read(self, stream):
+        self._data.append(self.buffer_reader(stream))
 
     def data(self):
         return np.asarray(self._data, dtype=self.dtype)
@@ -307,16 +307,16 @@ class TObjectReader(IReader):
         self.pidf = array("H")
         self.pidf_offsets = array("q", [0])
 
-    def read(self, buffer):
-        buffer.skip_fVersion()
-        fUniqueID = buffer.read_int32()
-        fBits = buffer.read_uint32()
+    def read(self, stream):
+        stream.skip_fVersion()
+        fUniqueID = stream.read_int32()
+        fBits = stream.read_uint32()
 
         if fBits & kIsReferenced:
             if self.keep_data:
-                self.pidf.append(buffer.read_uint16())
+                self.pidf.append(stream.read_uint16())
             else:
-                buffer.skip(2)
+                stream.skip(2)
 
         if self.keep_data:
             self.unique_id.append(fUniqueID)
@@ -342,16 +342,16 @@ class TStringReader(IReader):
         self._data = array("B")
         self.offsets = array("q", [0])
 
-    def read(self, buffer):
-        fSize = buffer.read_uint8()
+    def read(self, stream):
+        fSize = stream.read_uint8()
         if fSize == 255:
-            fSize = buffer.read_uint32()
+            fSize = stream.read_uint32()
 
         for _ in range(fSize):
-            self._data.append(buffer.read_uint8())
+            self._data.append(stream.read_uint8())
         self.offsets.append(len(self._data))
 
-    def read_many(self, buffer, count):
+    def read_many(self, stream, count):
         assert (
             count >= 0
         ), f"Calling {self.name}.read_many with negative count: {count} is not allowed"
@@ -360,25 +360,25 @@ class TStringReader(IReader):
             return 0
 
         if self.with_header:
-            buffer.skip_fNBytes()
-            buffer.skip_fVersion()
+            stream.skip_fNBytes()
+            stream.skip_fVersion()
 
         for _ in range(count):
-            self.read(buffer)
+            self.read(stream)
 
         return count
 
-    def read_until(self, buffer, end_pos):
-        if buffer.cursor == end_pos:
+    def read_until(self, stream, end_pos):
+        if stream.cursor == end_pos:
             return 0
 
         if self.with_header:
-            buffer.skip_fNBytes()
-            buffer.skip_fVersion()
+            stream.skip_fNBytes()
+            stream.skip_fVersion()
 
         count = 0
-        while buffer.cursor < end_pos:
-            self.read(buffer)
+        while stream.cursor < end_pos:
+            self.read(stream)
             count += 1
         return count
 
@@ -414,40 +414,40 @@ class STLSeqReader(IReader):
                 f"STLSeqReader({self.name}) expected member-wise reading but got obj-wise"
             )
 
-    def read_element_version(self, buffer: BinaryBuffer):
-        version = buffer.read_fVersion()
+    def read_element_version(self, stream: BinaryStream):
+        version = stream.read_fVersion()
         checksum = None
         if version == 0:
-            checksum = buffer.read_uint32()
+            checksum = stream.read_uint32()
         return version, checksum
 
-    def read_body(self, buffer: BinaryBuffer, is_memberwise: bool):
-        fSize = buffer.read_uint32()
+    def read_body(self, stream: BinaryStream, is_memberwise: bool):
+        fSize = stream.read_uint32()
         self.offsets.append(self.offsets[-1] + fSize)
 
         debug_print(
             f"STLSeqReader({self.name}): reading body, is_memberwise={is_memberwise}, fSize={fSize}\n"
         )
-        debug_print(buffer)
+        debug_print(stream)
 
         if is_memberwise:
-            self.element_reader.read_many_memberwise(buffer, fSize)
+            self.element_reader.read_many_memberwise(stream, fSize)
         else:
-            self.element_reader.read_many(buffer, fSize)
+            self.element_reader.read_many(stream, fSize)
 
-    def read(self, buffer):
-        buffer.skip_fNBytes()
+    def read(self, stream):
+        stream.skip_fNBytes()
 
-        fVersion = buffer.read_fVersion()
+        fVersion = stream.read_fVersion()
         is_memberwise = bool(fVersion & kStreamedMemberwise)
         self.check_objwise_memberwise(is_memberwise)
 
         if is_memberwise:
-            self.read_element_version(buffer)
+            self.read_element_version(stream)
 
-        self.read_body(buffer, is_memberwise)
+        self.read_body(stream, is_memberwise)
 
-    def read_many(self, buffer, count):
+    def read_many(self, stream, count):
         if count == 0:
             return 0
 
@@ -456,55 +456,55 @@ class STLSeqReader(IReader):
                 self.with_header
             ), f"STLSeqReader({self.name}).read_many called with negative count expects with_header=True"
 
-            fNBytes = buffer.read_fNBytes()
-            end_pos = buffer.cursor + fNBytes
+            fNBytes = stream.read_fNBytes()
+            end_pos = stream.cursor + fNBytes
 
-            fVersion = buffer.read_fVersion()
+            fVersion = stream.read_fVersion()
             is_memberwise = bool(fVersion & kStreamedMemberwise)
             self.check_objwise_memberwise(is_memberwise)
 
             if is_memberwise:
-                self.read_element_version(buffer)
+                self.read_element_version(stream)
 
             cur_count = 0
-            while buffer.cursor < end_pos:
-                self.read_body(buffer, is_memberwise)
+            while stream.cursor < end_pos:
+                self.read_body(stream, is_memberwise)
                 cur_count += 1
             return cur_count
 
         else:
             is_memberwise = self.objwise_or_memberwise == "member-wise"
             if self.with_header:
-                buffer.skip_fNBytes()
-                fVersion = buffer.read_fVersion()
+                stream.skip_fNBytes()
+                fVersion = stream.read_fVersion()
                 is_memberwise = bool(fVersion & kStreamedMemberwise)
                 self.check_objwise_memberwise(is_memberwise)
 
             if is_memberwise:
-                self.read_element_version(buffer)
+                self.read_element_version(stream)
 
             for _ in range(count):
-                self.read_body(buffer, is_memberwise)
+                self.read_body(stream, is_memberwise)
             return count
 
-    def read_until(self, buffer, end_pos):
-        if buffer.cursor == end_pos:
+    def read_until(self, stream, end_pos):
+        if stream.cursor == end_pos:
             return 0
 
         is_memberwise = self.objwise_or_memberwise == "member-wise"
 
         if self.with_header:
-            buffer.skip_fNBytes()
-            fVersion = buffer.read_fVersion()
+            stream.skip_fNBytes()
+            fVersion = stream.read_fVersion()
             is_memberwise = bool(fVersion & kStreamedMemberwise)
             self.check_objwise_memberwise(is_memberwise)
 
         if is_memberwise:
-            self.read_element_version(buffer)
+            self.read_element_version(stream)
 
         count = 0
-        while buffer.cursor < end_pos:
-            self.read_body(buffer, is_memberwise)
+        while stream.cursor < end_pos:
+            self.read_body(stream, is_memberwise)
             count += 1
         return count
 
@@ -542,41 +542,41 @@ class STLMapReader(IReader):
                 f"STLMapReader({self.name}) expected member-wise reading but got obj-wise"
             )
 
-    def read_element_version(self, buffer: BinaryBuffer):
-        version = buffer.read_fVersion()
+    def read_element_version(self, stream: BinaryStream):
+        version = stream.read_fVersion()
         checksum = None
         if version == 0:
-            checksum = buffer.read_uint32()
+            checksum = stream.read_uint32()
         return version, checksum
 
-    def read_body(self, buffer: BinaryBuffer, is_memberwise: bool):
-        fSize = buffer.read_uint32()
+    def read_body(self, stream: BinaryStream, is_memberwise: bool):
+        fSize = stream.read_uint32()
         self.offsets.append(self.offsets[-1] + fSize)
 
         debug_print(
             f"STLMapReader({self.name}): reading body, is_memberwise={is_memberwise}, fSize={fSize}\n"
         )
-        debug_print(buffer)
+        debug_print(stream)
 
         if is_memberwise:
-            self.key_reader.read_many(buffer, fSize)
-            self.value_reader.read_many(buffer, fSize)
+            self.key_reader.read_many(stream, fSize)
+            self.value_reader.read_many(stream, fSize)
         else:
             for _ in range(fSize):
-                self.key_reader.read(buffer)
-                self.value_reader.read(buffer)
+                self.key_reader.read(stream)
+                self.value_reader.read(stream)
 
-    def read(self, buffer):
-        buffer.skip_fNBytes()
-        fVersion = buffer.read_fVersion()
+    def read(self, stream):
+        stream.skip_fNBytes()
+        fVersion = stream.read_fVersion()
 
-        self.read_element_version(buffer)
+        self.read_element_version(stream)
 
         is_memberwise = bool(fVersion & kStreamedMemberwise)
         self.check_objwise_memberwise(is_memberwise)
-        self.read_body(buffer, is_memberwise)
+        self.read_body(stream, is_memberwise)
 
-    def read_many(self, buffer, count):
+    def read_many(self, stream, count):
         if count == 0:
             return 0
 
@@ -585,59 +585,59 @@ class STLMapReader(IReader):
                 self.with_header
             ), f"STLMapReader({self.name}).read_many called with negative count expecting with_header=True"
 
-            fNBytes = buffer.read_fNBytes()
-            end_pos = buffer.cursor + fNBytes
+            fNBytes = stream.read_fNBytes()
+            end_pos = stream.cursor + fNBytes
 
-            fVersion = buffer.read_fVersion()
+            fVersion = stream.read_fVersion()
 
-            self.read_element_version(buffer)
+            self.read_element_version(stream)
 
             is_memberwise = bool(fVersion & kStreamedMemberwise)
             self.check_objwise_memberwise(is_memberwise)
 
             cur_count = 0
-            while buffer.cursor < end_pos:
-                self.read_body(buffer, is_memberwise)
+            while stream.cursor < end_pos:
+                self.read_body(stream, is_memberwise)
                 cur_count += 1
             return cur_count
 
         else:
             is_memberwise = self.objwise_or_memberwise == "member-wise"
             if self.with_header:
-                buffer.skip_fNBytes()
-                fVersion = buffer.read_fVersion()
+                stream.skip_fNBytes()
+                fVersion = stream.read_fVersion()
 
-                self.read_element_version(buffer)
+                self.read_element_version(stream)
 
                 is_memberwise = bool(fVersion & kStreamedMemberwise)
                 self.check_objwise_memberwise(is_memberwise)
 
             for _ in range(count):
-                self.read_body(buffer, is_memberwise)
+                self.read_body(stream, is_memberwise)
             return count
 
-    def read_until(self, buffer, end_pos):
-        if buffer.cursor == end_pos:
+    def read_until(self, stream, end_pos):
+        if stream.cursor == end_pos:
             return 0
 
         is_memberwise = self.objwise_or_memberwise == "member-wise"
 
         if self.with_header:
-            buffer.skip_fNBytes()
-            fVersion = buffer.read_fVersion()
+            stream.skip_fNBytes()
+            fVersion = stream.read_fVersion()
 
-            self.read_element_version(buffer)
+            self.read_element_version(stream)
 
             is_memberwise = bool(fVersion & kStreamedMemberwise)
             self.check_objwise_memberwise(is_memberwise)
 
         count = 0
-        while buffer.cursor < end_pos:
-            self.read_body(buffer, is_memberwise)
+        while stream.cursor < end_pos:
+            self.read_body(stream, is_memberwise)
             count += 1
         return count
 
-    def read_many_memberwise(self, buffer, count):
+    def read_many_memberwise(self, stream, count):
         assert (
             count >= 0
         ), f"Calling {self.name}.read_many_memberwise with negative count: {count} is not allowed"
@@ -645,7 +645,7 @@ class STLMapReader(IReader):
         is_memberwise = True
 
         self.check_objwise_memberwise(is_memberwise)
-        return self.read_many(buffer, count)
+        return self.read_many(stream, count)
 
     def data(self):
         offsets_array = np.asarray(self.offsets)
@@ -662,22 +662,22 @@ class STLStringReader(IReader):
         self._data = array("B")
         self.offsets = array("q", [0])
 
-    def read_body(self, buffer: BinaryBuffer):
-        fSize = buffer.read_uint8()
+    def read_body(self, stream: BinaryStream):
+        fSize = stream.read_uint8()
         if fSize == 255:
-            fSize = buffer.read_uint32()
+            fSize = stream.read_uint32()
 
         self.offsets.append(self.offsets[-1] + fSize)
         for _ in range(fSize):
-            self._data.append(buffer.read_uint8())
+            self._data.append(stream.read_uint8())
 
-    def read(self, buffer):
+    def read(self, stream):
         if self.with_header:
-            buffer.skip_fNBytes()
-            buffer.skip_fVersion()
-        self.read_body(buffer)
+            stream.skip_fNBytes()
+            stream.skip_fVersion()
+        self.read_body(stream)
 
-    def read_many(self, buffer, count):
+    def read_many(self, stream, count):
         if count == 0:
             return 0
 
@@ -686,37 +686,37 @@ class STLStringReader(IReader):
                 self.with_header
             ), f"STLStringReader({self.name}).read_many called with negative count expecting with_header=True"
 
-            fNBytes = buffer.read_fNBytes()
-            end_pos = buffer.cursor + fNBytes
+            fNBytes = stream.read_fNBytes()
+            end_pos = stream.cursor + fNBytes
 
-            buffer.skip_fVersion()
+            stream.skip_fVersion()
 
             cur_count = 0
-            while buffer.cursor < end_pos:
-                self.read_body(buffer)
+            while stream.cursor < end_pos:
+                self.read_body(stream)
                 cur_count += 1
             return cur_count
 
         else:
             if self.with_header:
-                buffer.skip_fNBytes()
-                buffer.skip_fVersion()
+                stream.skip_fNBytes()
+                stream.skip_fVersion()
 
             for _ in range(count):
-                self.read_body(buffer)
+                self.read_body(stream)
             return count
 
-    def read_until(self, buffer, end_pos):
-        if buffer.cursor == end_pos:
+    def read_until(self, stream, end_pos):
+        if stream.cursor == end_pos:
             return 0
 
         if self.with_header:
-            buffer.skip_fNBytes()
-            buffer.skip_fVersion()
+            stream.skip_fNBytes()
+            stream.skip_fVersion()
 
         count = 0
-        while buffer.cursor < end_pos:
-            self.read_body(buffer)
+        while stream.cursor < end_pos:
+            self.read_body(stream)
             count += 1
         return count
 
@@ -739,12 +739,12 @@ class TArrayReader(IReader):
         self.offsets = array("q", [0])
         self.buffer_reader = DTYPE_TO_READER[dtype]
 
-    def read(self, buffer):
-        fSize = buffer.read_uint32()
+    def read(self, stream):
+        fSize = stream.read_uint32()
         self.offsets.append(self.offsets[-1] + fSize)
 
         for _ in range(fSize):
-            self._data.append(self.buffer_reader(buffer))
+            self._data.append(self.buffer_reader(stream))
 
     def data(self):
         offsets_array = np.asarray(self.offsets)
@@ -757,13 +757,13 @@ class GroupReader(IReader):
         super().__init__(name)
         self.element_readers = element_readers
 
-    def read(self, buffer):
+    def read(self, stream):
         for reader in self.element_readers:
             debug_print(f"GroupReader({self.name}) reading element {reader.name}:\n")
-            debug_print(buffer)
-            reader.read(buffer)
+            debug_print(stream)
+            reader.read(stream)
 
-    def read_many_memberwise(self, buffer, count):
+    def read_many_memberwise(self, stream, count):
         assert (
             count >= 0
         ), f"Calling {self.name}.read_many_memberwise with negative count: {count} is not allowed"
@@ -772,8 +772,8 @@ class GroupReader(IReader):
             debug_print(
                 f"GroupReader{self.name} reading many member-wise element {reader.name}:\n"
             )
-            debug_print(buffer)
-            reader.read_many(buffer, count)
+            debug_print(stream)
+            reader.read_many(stream, count)
 
         return count
 
@@ -786,24 +786,24 @@ class AnyClassReader(IReader):
         super().__init__(name)
         self.element_readers = element_readers
 
-    def read(self, buffer: BinaryBuffer):
-        fNBytes = buffer.read_fNBytes()
-        start_pos = buffer.cursor
+    def read(self, stream: BinaryStream):
+        fNBytes = stream.read_fNBytes()
+        start_pos = stream.cursor
         end_pos = start_pos + fNBytes
 
-        buffer.skip_fVersion()
+        stream.skip_fVersion()
 
         for reader in self.element_readers:
             debug_print(f"AnyClassReader({self.name}) reading element {reader.name}:\n")
-            debug_print(buffer)
-            reader.read(buffer)
+            debug_print(stream)
+            reader.read(stream)
 
-        assert buffer.cursor == end_pos, (
+        assert stream.cursor == end_pos, (
             f"AnyClassReader({self.name}): Invalid read length! Expect {fNBytes} bytes, "
-            f"but read {buffer.cursor - start_pos} bytes."
+            f"but read {stream.cursor - start_pos} bytes."
         )
 
-    def read_many_memberwise(self, buffer, count):
+    def read_many_memberwise(self, stream, count):
         assert (
             count >= 0
         ), f"Calling {self.name}.read_many_memberwise with negative count: {count} is not allowed"
@@ -812,8 +812,8 @@ class AnyClassReader(IReader):
             debug_print(
                 f"AnyClassReader{self.name} reading many member-wise element {reader.name}:\n"
             )
-            debug_print(buffer)
-            reader.read_many(buffer, count)
+            debug_print(stream)
+            reader.read_many(stream, count)
 
         return count
 
@@ -848,10 +848,10 @@ class AnyPointerReader(IReader):
 
         self.class_name = None
 
-    def read(self, buffer):
-        start_pos = buffer.cursor
-        ref_begin = start_pos + buffer.initial_cursor_position
-        fNBytes = buffer.read_uint32()
+    def read(self, stream):
+        start_pos = stream.cursor
+        ref_begin = start_pos + stream.initial_cursor_position
+        fNBytes = stream.read_uint32()
 
         if (fNBytes & kByteCountMask) == 0 or fNBytes == kNewClassTag:
             fVersion = 0
@@ -860,7 +860,7 @@ class AnyPointerReader(IReader):
             fNBytes = 0
         else:
             fVersion = 1
-            fTag = buffer.read_uint32()
+            fTag = stream.read_uint32()
             fNBytes &= ~kByteCountMask
 
         end_pos = start_pos + 4 + fNBytes if fVersion > 0 else start_pos + 4
@@ -868,29 +868,29 @@ class AnyPointerReader(IReader):
         if fTag & kClassMask == 0:
             if fTag == 0:
                 assert (
-                    buffer.cursor == end_pos
-                ), f"AnyPointerReader({self.name}): Invalid read length! Expect to read 0 bytes, but read {buffer.cursor - start_pos} bytes."
+                    stream.cursor == end_pos
+                ), f"AnyPointerReader({self.name}): Invalid read length! Expect to read 0 bytes, but read {stream.cursor - start_pos} bytes."
                 self.object_indexes.append(-1)  # Use -1 to indicate null pointer
                 return
 
             elif fTag == 1:
                 raise NotImplementedError("AnyPointerReader: kAnyP (tag=1) is not supported")
 
-            elif fTag not in buffer.refs:
-                buffer.cursor = end_pos  # Skip unknown reference
+            elif fTag not in stream.refs:
+                stream.cursor = end_pos  # Skip unknown reference
                 return
 
             else:
-                ref_idx = buffer.refs[fTag].object_index
+                ref_idx = stream.refs[fTag].object_index
                 self.object_indexes.append(ref_idx)
 
                 assert (
-                    buffer.cursor == end_pos
-                ), f"AnyPointerReader({self.name}): Invalid read length! Expect to read 0 bytes, but read {buffer.cursor - start_pos} bytes."
+                    stream.cursor == end_pos
+                ), f"AnyPointerReader({self.name}): Invalid read length! Expect to read 0 bytes, but read {stream.cursor - start_pos} bytes."
                 return
 
         elif fTag == kNewClassTag:
-            class_name = buffer.read_null_terminated_string()
+            class_name = stream.read_null_terminated_string()
             if self.class_name is None:
                 self.class_name = class_name
             else:
@@ -899,39 +899,39 @@ class AnyPointerReader(IReader):
                     f"Expected {self.class_name}, but got {class_name}"
                 )
 
-            ref_key = ref_begin + kMapOffset if fVersion > 0 else len(buffer.refs) + 1
-            buffer.refs[ref_key] = _Reference(type="class", class_name=class_name)
+            ref_key = ref_begin + kMapOffset if fVersion > 0 else len(stream.refs) + 1
+            stream.refs[ref_key] = _Reference(type="class", class_name=class_name)
 
-            self.element_reader.read(buffer)
+            self.element_reader.read(stream)
             self.object_indexes.append(self.object_counter)
 
-            ref_key = ref_begin + kMapOffset if fVersion > 0 else len(buffer.refs) + 1
-            buffer.refs[ref_key] = _Reference(type="object", object_index=self.object_counter)
+            ref_key = ref_begin + kMapOffset if fVersion > 0 else len(stream.refs) + 1
+            stream.refs[ref_key] = _Reference(type="object", object_index=self.object_counter)
 
             self.object_counter += 1
 
         else:  # reference class, new object
             cls_ref_key = fTag & (~kClassMask)
-            if cls_ref_key in buffer.refs:
-                class_name = buffer.refs[cls_ref_key].class_name
+            if cls_ref_key in stream.refs:
+                class_name = stream.refs[cls_ref_key].class_name
                 assert class_name == self.class_name, (
                     f"AnyPointerReader({self.name}): Inconsistent class names for multiple objects! "
                     f"Expected {self.class_name}, but got {class_name}"
                 )
 
-            self.element_reader.read(buffer)
+            self.element_reader.read(stream)
             self.object_indexes.append(self.object_counter)
 
-            obj_ref_key = ref_begin + kMapOffset if fVersion > 0 else len(buffer.refs) + 1
-            buffer.refs[obj_ref_key] = _Reference(
+            obj_ref_key = ref_begin + kMapOffset if fVersion > 0 else len(stream.refs) + 1
+            stream.refs[obj_ref_key] = _Reference(
                 type="object", object_index=self.object_counter
             )
 
             self.object_counter += 1
 
         assert (
-            buffer.cursor == end_pos
-        ), f"AnyPointerReader({self.name}): Invalid read length! Expect to read 0 bytes, but read {buffer.cursor - start_pos} bytes."
+            stream.cursor == end_pos
+        ), f"AnyPointerReader({self.name}): Invalid read length! Expect to read 0 bytes, but read {stream.cursor - start_pos} bytes."
         return
 
     def data(self):
@@ -946,27 +946,27 @@ class ObjectHeaderReader(IReader):
 
         warnings.warn(
             "ObjectHeaderReader is deprecated and will be removed in a future version. "
-            "Use BinaryBuffer.read_obj_header() directly in your reader instead.",
+            "Use BinaryStream.read_obj_header() directly in your reader instead.",
             DeprecationWarning,
         )
 
         super().__init__(name)
         self.element_reader = element_reader
 
-    def read(self, buffer):
-        fNBytes = buffer.read_fNBytes()
-        start_pos = buffer.cursor
-        end_pos = buffer.cursor + fNBytes
+    def read(self, stream):
+        fNBytes = stream.read_fNBytes()
+        start_pos = stream.cursor
+        end_pos = stream.cursor + fNBytes
 
-        fTag = buffer.read_int32()
+        fTag = stream.read_int32()
         if fTag == kNewClassTag:
-            buffer.skip_null_terminated_string()
+            stream.skip_null_terminated_string()
 
-        self.element_reader.read(buffer)
+        self.element_reader.read(stream)
 
-        assert buffer.cursor == end_pos, (
+        assert stream.cursor == end_pos, (
             f"ObjectHeaderReader({self.name}): Invalid read length! Expect {fNBytes} bytes, "
-            f"but read {buffer.cursor - start_pos} bytes."
+            f"but read {stream.cursor - start_pos} bytes."
         )
 
     def data(self):
@@ -980,26 +980,26 @@ class CStyleArrayReader(IReader):
         self.element_reader = element_reader
         self.offsets = array("q", [0])
 
-    def read(self, buffer):
+    def read(self, stream):
         debug_print(
             f"CStyleArrayReader({self.name}): reading C-style array of flat_size={self.flat_size}\n"
         )
-        debug_print(buffer)
+        debug_print(stream)
 
         if self.flat_size >= 0:
-            self.element_reader.read_many(buffer, self.flat_size)
+            self.element_reader.read_many(stream, self.flat_size)
 
         else:
-            entry_offsets = buffer.offsets
-            cursor_pos = buffer.cursor
+            entry_offsets = stream.offsets
+            cursor_pos = stream.cursor
             end_offset_index = (entry_offsets > cursor_pos).nonzero()[0].min()
             end_pos = entry_offsets[end_offset_index]
 
-            count = self.element_reader.read_until(buffer, end_pos)
+            count = self.element_reader.read_until(stream, end_pos)
             self.offsets.append(self.offsets[-1] + count)
             debug_print(f"CStyleArrayReader({self.name}): read {count} elements")
 
-    def read_many(self, buffer, count):
+    def read_many(self, stream, count):
         assert (
             self.flat_size >= 0
         ), f"Calling CStyleArrayReader({self.name}).read_many with negative flat_size is not allowed"
@@ -1009,11 +1009,11 @@ class CStyleArrayReader(IReader):
         ), f"Calling CStyleArrayReader({self.name}).read_many with negative count: {count} is not allowed"
 
         for _ in range(count):
-            self.element_reader.read_many(buffer, self.flat_size)
+            self.element_reader.read_many(stream, self.flat_size)
 
         return count
 
-    def read_until(self, buffer, end_pos):
+    def read_until(self, stream, end_pos):
         raise NotImplementedError("CStyleArrayReader.read_until is not supported")
 
     def data(self):
@@ -1026,7 +1026,7 @@ class CStyleArrayReader(IReader):
 
 
 class EmptyReader(IReader):
-    def read(self, buffer):
+    def read(self, stream):
         pass
 
     def data(self):
@@ -1039,15 +1039,15 @@ def read_data(
     cursor_offset: int,
     reader: IReader,
 ):
-    buffer = BinaryBuffer(data, offsets, cursor_offset)
-    for i_evt in range(buffer.entries):
-        start_pos = buffer.cursor
-        reader.read(buffer)
-        end_pos = buffer.cursor
+    stream = BinaryStream(data, offsets, cursor_offset)
+    for i_evt in range(stream.entries):
+        start_pos = stream.cursor
+        reader.read(stream)
+        end_pos = stream.cursor
 
         assert end_pos == offsets[i_evt + 1], (
             f"read_data: Invalid read length for {reader.name} at entry {i_evt}! Expect "
-            f"{buffer.offsets[i_evt + 1]-buffer.offsets[i_evt]} bytes, but read {end_pos - start_pos} bytes."
+            f"{stream.offsets[i_evt + 1]-stream.offsets[i_evt]} bytes, but read {end_pos - start_pos} bytes."
         )
 
     return reader.data()


### PR DESCRIPTION
This pull request updates the terminology and codebase to consistently use "BinaryStream" instead of "BinaryBuffer" throughout the C++ and Python reader APIs, documentation, and examples. It also introduces a deprecated alias for backward compatibility and updates all relevant method parameters, comments, and docstrings to reflect this change.

### Core API and Naming Updates

* Renamed the C++ class `BinaryBuffer` to `BinaryStream` in `uproot-custom.hh`, updating all constructors, method parameters, and docstrings accordingly. A deprecated alias `BinaryBuffer` is provided for backward compatibility. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L50-R50) [[2]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L78-R82) [[3]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29R314-R318)
* Updated all references to "buffer" in docstrings and comments to "stream" for clarity and consistency. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L91-R94) [[2]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L139-R146) [[3]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L159-R161) [[4]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L171-R171) [[5]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L186-R190) [[6]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L201-R201) [[7]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L219-R227) [[8]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L238-R238) [[9]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L345-R354) [[10]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L360-R411) [[11]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L512-R530)

### Reader Interface and Example Updates

* Changed all `read`, `read_many`, `read_until`, and related method signatures in `IReader` and example classes to use `BinaryStream` instead of `BinaryBuffer` in both C++ and Python. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L345-R354) [[2]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L360-R411) [[3]](diffhunk://#diff-52fc81db760aa205bb7eb38f6257770408993ba1c88c35a445cfb28421b33baeL129-R142) [[4]](diffhunk://#diff-52fc81db760aa205bb7eb38f6257770408993ba1c88c35a445cfb28421b33baeL329-R345) [[5]](diffhunk://#diff-ff64f51f13b722845ff02b6ea5b154b33b1b7880fbb37ae2c4ada18082632b07L221-R221) [[6]](diffhunk://#diff-ff64f51f13b722845ff02b6ea5b154b33b1b7880fbb37ae2c4ada18082632b07L230-R243) [[7]](diffhunk://#diff-ff64f51f13b722845ff02b6ea5b154b33b1b7880fbb37ae2c4ada18082632b07L455-R464)

### Documentation and Tutorial Consistency

* Updated all documentation, tutorials, and code examples to refer to "binary streams" and `BinaryStream` (instead of "binary buffers" and `BinaryBuffer`), including diagrams, usage instructions, and seealso references. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L42-R42) [[3]](diffhunk://#diff-52fc81db760aa205bb7eb38f6257770408993ba1c88c35a445cfb28421b33baeL305-R305) [[4]](diffhunk://#diff-ff64f51f13b722845ff02b6ea5b154b33b1b7880fbb37ae2c4ada18082632b07L437-R437) [[5]](diffhunk://#diff-a90a1be88942e0fcaa47375183cfaaa56e5a68fb768cbaffe81372d02d7f10fdL45-R45) [[6]](diffhunk://#diff-f7510de70209f15969c2dac78dc23bb8bfb33b328094770b187d3ea48bce3440L19-R19)

These changes ensure a consistent and modern terminology across the codebase and documentation, making the API clearer for both Python and C++ users.