### PR TITLE
docs: update terminology for lazy evaluation in factory and reader documentation

### DIFF
--- a/docs/example/override-streamer.md
+++ b/docs/example/override-streamer.md
@@ -156,7 +156,7 @@ class OverrideStreamerReader(IReader):
 
 To use our `OverrideStreamerReader` and reconstruct the final `awkward` array, we need to implement a corresponding Factory. We can implement a Factory named `OverrideStreamerFactory` to do this.
 
-A Factory requires at least 3 methods: `build_factory`, `build_python_reader` and `make_awkward_content`. An optional method `make_awkward_form` can be implemented to enable `dask` functionality.
+A Factory requires at least 3 methods: `build_factory`, `build_python_reader` and `make_awkward_content`. An optional method `make_awkward_form` can be implemented to enable lazy evaluation functionality.
 
 First, import necessary modules:
 

--- a/docs/tutorial/customize-factory-reader.md
+++ b/docs/tutorial/customize-factory-reader.md
@@ -18,7 +18,7 @@ By the end of this tutorial you will have:
 
 - A **Python reader** that decodes binary data from the ROOT byte stream.
 - A **Python factory** that creates the reader, converts raw arrays into
-  `awkward` arrays, and describes the data layout for `dask`.
+  `awkward` arrays, and describes the data layout for lazy evaluation.
 - A **registration** step so Uproot picks up your custom code automatically.
 - A **C++ reader** for production-level performance.
 

--- a/docs/tutorial/customize-factory-reader/pipeline.md
+++ b/docs/tutorial/customize-factory-reader/pipeline.md
@@ -153,7 +153,7 @@ sub-reader to consume its portion of the stream:
 ```{code-block} python
 ---
 caption: "`AnyClassReader.read` method (Python)"
-emphasize-lines: 7
+emphasize-lines: 8
 ---
 def read(self, stream):
     fNBytes = stream.read_fNBytes()
@@ -224,7 +224,7 @@ class GroupFactory(Factory):
 ### Generating awkward forms
 
 `awkward` forms describe the data structure without holding data, enabling
-lazy evaluation with `dask`. Form generation mirrors `make_awkward_content` but
+lazy evaluation like `dask` and awkward virtual arrays. Form generation mirrors `make_awkward_content` but
 needs no input data:
 
 ```{code-block} python
@@ -350,7 +350,7 @@ class OverrideStreamerFactory(Factory):
         )
 
     def make_awkward_form(self):
-        # Stage 5b — describe the data layout for dask
+        # Stage 5b — describe the data layout for lazy evaluation
         return awkward.forms.RecordForm(
             [awkward.forms.NumpyForm("int32"),
              awkward.forms.NumpyForm("float64")],

--- a/docs/tutorial/customize-factory-reader/pipeline.md
+++ b/docs/tutorial/customize-factory-reader/pipeline.md
@@ -224,7 +224,7 @@ class GroupFactory(Factory):
 ### Generating awkward forms
 
 `awkward` forms describe the data structure without holding data, enabling
-lazy evaluation like `dask` and awkward virtual arrays. Form generation mirrors `make_awkward_content` but
+lazy evaluation functionality. Form generation mirrors `make_awkward_content` but
 needs no input data:
 
 ```{code-block} python

--- a/docs/tutorial/customize-factory-reader/reader-and-factory.md
+++ b/docs/tutorial/customize-factory-reader/reader-and-factory.md
@@ -268,8 +268,7 @@ an `awkward.contents.Content`.
 
 ### `make_awkward_form`
 
-Return an `awkward.forms.Form` that describes the data layout. This is used
-by `dask` for lazy evaluation.
+Return an `awkward.forms.Form` that describes the data layout. This is used for lazy evaluation.
 
 ```{seealso}
 [`awkward` forms reference](https://awkward-array.org/doc/main/reference/generated/ak.forms.Form.html)


### PR DESCRIPTION
This pull request updates the documentation to clarify that the `make_awkward_form` method and related factory/reader functionality support general lazy evaluation, not just `dask`. The changes update language throughout the docs to avoid implying that only `dask` is supported, and instead refer to lazy evaluation and virtual arrays more broadly.

**Documentation updates for lazy evaluation:**

* Updated references to `dask` in the context of `make_awkward_form` and factory requirements to instead describe support for general lazy evaluation and awkward virtual arrays. [[1]](diffhunk://#diff-52fc81db760aa205bb7eb38f6257770408993ba1c88c35a445cfb28421b33baeL159-R159) [[2]](diffhunk://#diff-f7510de70209f15969c2dac78dc23bb8bfb33b328094770b187d3ea48bce3440L21-R21) [[3]](diffhunk://#diff-46640fc1ca7c6b1d3414003a2342eac3216fff8a019e284115b585b4971e02d9L227-R227) [[4]](diffhunk://#diff-46640fc1ca7c6b1d3414003a2342eac3216fff8a019e284115b585b4971e02d9L353-R353) [[5]](diffhunk://#diff-09d2d5d86758f9f0f9e6e4bdbe8232d614371849c98b58d79d1ef218d3a89edeL271-R271)

**Code block formatting:**

* Fixed code block line highlighting in the tutorial for clarity.