### PR TITLE
feat: add caching mechanism for ForthMachine64 instances

### DIFF
--- a/uproot_custom/readers/_forth.py
+++ b/uproot_custom/readers/_forth.py
@@ -97,6 +97,9 @@ def to_typecode(dtype_or_typecode: str) -> TYPECODE:
     raise ValueError(f"Unsupported dtype/typecode: {dtype_or_typecode}")
 
 
+_vm_cache: dict[str, ak.forth.ForthMachine64] = {}
+
+
 def read_data(data: bytes, offsets: np.ndarray, reader: IReader):
     read_single_evt_code = reader.compile()
 
@@ -139,7 +142,12 @@ def read_data(data: bytes, offsets: np.ndarray, reader: IReader):
 
     codes = _format_forth_codes(codes)
 
-    vm = ak.forth.ForthMachine64(codes)
+    if codes in _vm_cache:
+        vm = _vm_cache[codes]
+    else:
+        vm = ak.forth.ForthMachine64(codes)
+        _vm_cache[codes] = vm
+
     vm.run(
         {
             stream_data_token: data.copy(),


### PR DESCRIPTION
This pull request introduces a caching mechanism to optimize the instantiation of `ForthMachine64` virtual machines in the `uproot_custom/readers/_forth.py` module. By reusing previously created VMs for identical code sequences, the changes aim to improve performance and reduce redundant object creation.

**Performance improvements:**

* Introduced a module-level cache `_vm_cache` to store and reuse `ak.forth.ForthMachine64` instances, keyed by their code sequences.
* Updated the `read_data` function to check the cache before creating a new `ForthMachine64` instance, ensuring that VMs are reused when possible.