### PR TITLE
refactor: rename c++ namespace and optimize BinaryStream

### DIFF
--- a/cpp/include/uproot-custom/uproot-custom.hh
+++ b/cpp/include/uproot-custom/uproot-custom.hh
@@ -170,24 +170,17 @@ namespace uproot_custom {
         }
 
         /**
-         * @brief Read pointer header from the stream. The pointer header has `fNBytes`,
+         * @brief Read an object's header from the stream. The object header has `fNBytes`,
          * `fVersion`, `fTag`. If `fTag == kNewClassTag`, then a null-terminated class name
          * follows.
          *
-         * @return The class name if the pointer is a new class, empty string
-         * otherwise.
+         * @return The class name if the object is a new class, empty string otherwise.
          */
-        const std::string read_ptr_header() {
+        const std::string read_obj_header() {
             skip_fNBytes();
             auto fTag = read<uint32_t>();
             if ( fTag == kNewClassTag ) return read_null_terminated_string();
             else return std::string();
-        }
-
-        [[deprecated( "read_obj_header has been renamed to read_ptr_header, use "
-                      "read_ptr_header instead." )]] const std::string
-        read_obj_header() {
-            return read_ptr_header();
         }
 
         /**
@@ -232,20 +225,14 @@ namespace uproot_custom {
         }
 
         /**
-         * @brief Skip a pointer header in the stream. The pointer header has `fNBytes`,
+         * @brief Skip an object's header in the stream. The object header has `fNBytes`,
          * `fVersion`, `fTag`. If `fTag == kNewClassTag`, then a null-terminated class name
          * follows.
          */
-        void skip_ptr_header() {
+        void skip_obj_header() {
             skip_fNBytes();
             auto fTag = read<uint32_t>();
             if ( fTag == kNewClassTag ) skip_null_terminated_string();
-        }
-
-        [[deprecated( "skip_obj_header has been renamed to skip_ptr_header, use "
-                      "skip_ptr_header instead." )]] void
-        skip_obj_header() {
-            skip_ptr_header();
         }
 
         /**

--- a/cpp/include/uproot-custom/uproot-custom.hh
+++ b/cpp/include/uproot-custom/uproot-custom.hh
@@ -528,4 +528,6 @@ namespace uproot_custom {
 
 // backward compatibility
 // TODO: remove the uproot namespace and use uproot_custom namespace directly in the future.
-namespace uproot = uproot_custom;
+namespace uproot {
+    using namespace uproot_custom;
+}

--- a/cpp/include/uproot-custom/uproot-custom.hh
+++ b/cpp/include/uproot-custom/uproot-custom.hh
@@ -33,19 +33,19 @@
  */
 #define IMPORT_UPROOT_CUSTOM_CPP pybind11::module_::import( "uproot_custom.cpp" );
 
-namespace uproot {
+namespace uproot_custom {
     namespace py = pybind11;
     using std::shared_ptr;
 
-    const uint32_t kNewClassTag    = 0xFFFFFFFF;
-    const uint32_t kClassMask      = 0x80000000; // OR the class index with this
-    const uint32_t kByteCountMask  = 0x40000000; // OR the byte count with this
-    const uint32_t kMaxMapCount    = 0x3FFFFFFE; // last valid fMapCount and byte count
-    const uint16_t kByteCountVMask = 0x4000;     // OR the version byte count with this
-    const uint16_t kMaxVersion     = 0x3FFF;     // highest possible version number
-    const int32_t kMapOffset = 2; // first 2 map entries are taken by null obj and self obj
+    constexpr uint32_t kNewClassTag    = 0xFFFFFFFF;
+    constexpr uint32_t kClassMask      = 0x80000000; // OR the class index with this
+    constexpr uint32_t kByteCountMask  = 0x40000000; // OR the byte count with this
+    constexpr uint32_t kMaxMapCount    = 0x3FFFFFFE; // last valid fMapCount and byte count
+    constexpr uint16_t kByteCountVMask = 0x4000;     // OR the version byte count with this
+    constexpr uint16_t kMaxVersion     = 0x3FFF;     // highest possible version number
+    constexpr int32_t kMapOffset = 2; // first 2 map entries are taken by null obj and self obj
 
-    const uint16_t kStreamedMemberWise = 1 << 14; // streamed member-wise mask
+    constexpr uint16_t kStreamedMemberWise = 1 << 14; // streamed member-wise mask
 
     class BinaryStream {
       public:
@@ -97,10 +97,9 @@ namespace uproot {
         const T read() {
             constexpr auto size = sizeof( T );
 
-            switch ( size )
+            if constexpr ( size == 1 ) return *reinterpret_cast<const T*>( m_cursor++ );
+            else if constexpr ( size == 2 )
             {
-            case 1: return *reinterpret_cast<const T*>( m_cursor++ );
-            case 2: {
                 union {
                     T value;
                     uint16_t bits;
@@ -110,7 +109,8 @@ namespace uproot {
                 val.bits = bswap16( val.bits );
                 return val.value;
             }
-            case 4: {
+            else if constexpr ( size == 4 )
+            {
                 union {
                     T value;
                     uint32_t bits;
@@ -120,7 +120,8 @@ namespace uproot {
                 val.bits = bswap32( val.bits );
                 return val.value;
             }
-            case 8: {
+            else if constexpr ( size == 8 )
+            {
                 union {
                     T value;
                     uint64_t bits;
@@ -130,9 +131,10 @@ namespace uproot {
                 val.bits = bswap64( val.bits );
                 return val.value;
             }
-            default:
-                throw std::runtime_error( "Unsupported type size: " + std::to_string( size ) );
-            }
+            else
+                static_assert(
+                    sizeof( T ) == 0,
+                    "read<T>: unsupported type size (only 1, 2, 4, 8 bytes allowed)" );
         }
 
         /**
@@ -168,18 +170,24 @@ namespace uproot {
         }
 
         /**
-         * @brief Read an object header from the stream. The object header has `fNBytes`,
+         * @brief Read pointer header from the stream. The pointer header has `fNBytes`,
          * `fVersion`, `fTag`. If `fTag == kNewClassTag`, then a null-terminated class name
          * follows.
          *
-         * @return The class name if the object is a new class, empty string
+         * @return The class name if the pointer is a new class, empty string
          * otherwise.
          */
-        const std::string read_obj_header() {
-            read_fNBytes();
+        const std::string read_ptr_header() {
+            skip_fNBytes();
             auto fTag = read<uint32_t>();
             if ( fTag == kNewClassTag ) return read_null_terminated_string();
             else return std::string();
+        }
+
+        [[deprecated( "read_obj_header has been renamed to read_ptr_header, use "
+                      "read_ptr_header instead." )]] const std::string
+        read_obj_header() {
+            return read_ptr_header();
         }
 
         /**
@@ -224,14 +232,20 @@ namespace uproot {
         }
 
         /**
-         * @brief Skip an object header in the stream. The object header has `fNBytes`,
+         * @brief Skip a pointer header in the stream. The pointer header has `fNBytes`,
          * `fVersion`, `fTag`. If `fTag == kNewClassTag`, then a null-terminated class name
          * follows.
          */
-        void skip_obj_header() {
+        void skip_ptr_header() {
             skip_fNBytes();
             auto fTag = read<uint32_t>();
             if ( fTag == kNewClassTag ) skip_null_terminated_string();
+        }
+
+        [[deprecated( "skip_obj_header has been renamed to skip_ptr_header, use "
+                      "skip_ptr_header instead." )]] void
+        skip_obj_header() {
+            skip_ptr_header();
         }
 
         /**
@@ -240,7 +254,6 @@ namespace uproot {
          * follows.
          */
         void skip_TObject() {
-            // TODO: CanIgnoreTObjectStreamer() ?
             skip_fVersion();
             skip( 4 ); // fUniqueID
             auto fBits = read<uint32_t>();
@@ -496,8 +509,8 @@ namespace uproot {
     */
 
     /**
-     * @brief Debug print function. Prints only when macro or environment varialbe with name
-     * `UPROOT_DEBUG` is defined. Use this function like `printf()`.
+     * @brief Debug print function. Prints only when environment variable with name
+     * `UPROOT_CUSTOM_DEBUG` is defined. Use this function like `printf()`.
      *
      * @tparam Args Argument types. No need to specify explicitly.
      * @param msg The format string.
@@ -505,29 +518,27 @@ namespace uproot {
      */
     template <typename... Args>
     inline void debug_printf( const char* msg, Args... args ) {
-        bool do_print = getenv( "UPROOT_DEBUG" );
-#ifdef UPROOT_DEBUG
-        do_print = true;
-#endif
+        bool do_print = getenv( "UPROOT_CUSTOM_DEBUG" );
         if ( !do_print ) return;
         printf( msg, std::forward<Args>( args )... );
     }
 
     /**
-     * @brief Debug print function for BinaryStream. Prints only when macro or environment
-     * variable with name `UPROOT_DEBUG` is defined. Call @ref BinaryStream::debug_print()
-     * internally.
+     * @brief Debug print function for BinaryStream. Prints only when environment
+     * variable with name `UPROOT_CUSTOM_DEBUG` is defined. Call @ref
+     * BinaryStream::debug_print() internally.
      *
      * @param stream The BinaryStream to print.
      * @param n Number of bytes to print.
      */
-    inline void debug_printf( uproot::BinaryStream& stream, const size_t n = 100 ) {
-        bool do_print = getenv( "UPROOT_DEBUG" );
-#ifdef UPROOT_DEBUG
-        do_print = true;
-#endif
+    inline void debug_printf( uproot_custom::BinaryStream& stream, const size_t n = 100 ) {
+        bool do_print = getenv( "UPROOT_CUSTOM_DEBUG" );
         if ( !do_print ) return;
         stream.debug_print( n );
     }
 
-} // namespace uproot
+} // namespace uproot_custom
+
+// backward compatibility
+// TODO: remove the uproot namespace and use uproot_custom namespace directly in the future.
+namespace uproot = uproot_custom;

--- a/cpp/src/uproot-custom.cc
+++ b/cpp/src/uproot-custom.cc
@@ -12,7 +12,7 @@
 
 #include "uproot-custom/uproot-custom.hh"
 
-namespace uproot {
+namespace uproot_custom {
     using std::pair;
     using std::shared_ptr;
     using std::string;
@@ -1397,4 +1397,4 @@ namespace uproot {
         declare_reader<EmptyReader, string>( m, "EmptyReader" );
     }
 
-} // namespace uproot
+} // namespace uproot_custom


### PR DESCRIPTION
This pull request refactors the C++ codebase to consistently use the `uproot_custom` namespace instead of `uproot`, modernizes several constants, and improves debug print handling. It also makes the `read<T>` method in `BinaryStream` safer and more idiomatic, and clarifies some documentation. For backward compatibility, the old `uproot` namespace is aliased to `uproot_custom` for now.

### Namespace refactoring

* Changed all code in `uproot-custom.hh` and `uproot-custom.cc` to use the `uproot_custom` namespace instead of `uproot`, and added a backward-compatibility alias so existing code using `uproot` will still work. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L36-R48) [[2]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL15-R15) [[3]](diffhunk://#diff-fda6231e35786e9e22404cab5abc6397386c965b6f52662e993b5dac87038a6aL1400-R1400) [[4]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L499-R533)

### Constants modernization

* Updated several `const` constants to `constexpr` for compile-time evaluation in `uproot-custom.hh`.

### BinaryStream improvements

* Refactored the templated `read<T>` method to use `if constexpr` for type safety and clarity, and replaced the default case with a `static_assert` for unsupported sizes. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L100-L103) [[2]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L113-R113) [[3]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L123-R124) [[4]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L133-R137)

### Debug print handling

* Changed debug printing to only check the `UPROOT_CUSTOM_DEBUG` environment variable (removing the macro option), and updated documentation/comments accordingly.

### Minor documentation and logic fixes

* Clarified several docstrings, fixed minor typos, and replaced a call to `read_fNBytes()` with `skip_fNBytes()` in `read_obj_header()` for more accurate logic. [[1]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L171-R180) [[2]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L227-R228) [[3]](diffhunk://#diff-36f60c636c1ee8651d59ffc24ac40cf09480b3cbbbf1661920a693ffa6306b29L243)